### PR TITLE
Add static terms and privacy pages

### DIFF
--- a/privacy-notice.html
+++ b/privacy-notice.html
@@ -1,0 +1,370 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Notice - Pilot Dashboard</title>
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/layout.css" />
+    <link rel="stylesheet" href="assets/css/nav.css" />
+    <link rel="stylesheet" href="assets/css/darkmode.css" />
+    <link rel="stylesheet" href="assets/css/about.css" />
+    <script defer src="assets/js/header.js"></script>
+  </head>
+  <body>
+    <div class="scaling-wrapper">
+      <main>
+        <h1>Privacy Notice</h1>
+        <div id="versionRow">
+          Last updated: <span id="lastUpdated">June 01, 2025</span>
+        </div>
+        <div id="privacyContent"></div>
+        <script id="privacyMarkdown" type="text/plain">
+# **PRIVACY NOTICE**
+
+**Last updated June 01, 2025**
+
+This Privacy Notice for Lucas Hjort Rahr Hartung ("**I**," "**me**," or "**my**"), describes how and why I might access, collect, store, use, and/or share ("**process**") your personal information when you use my services ("**Services**"), including when you:
+
+* Visit my website at [https://pilot-dashboard.e57.dk](https://pilot-dashboard.e57.dk/), or any website of ours that links to this Privacy Notice  
+* Use Pilot Dashboard. Pilot Dashboard is a free, open-source web app designed to help pilots plan, log, and analyze their flights. It is built with a focus on simplicity, usability, and data privacy.  
+* Engage with me in other related ways, including any sales, marketing, or events
+
+**Questions or concerns?** Reading this Privacy Notice will help you understand your privacy rights and choices. I are responsible for making decisions about how your personal information is processed. If you do not agree with my policies and practices, please do not use my Services. If you still have any questions or concerns, please contact me at lhrh.privat@gmail.com.
+
+## **SUMMARY OF KEY POINTS**
+
+***This summary provides key points from my Privacy Notice, but you can find out more details about any of these topics by clicking the link following each key point or by using my [table of contents](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#toc) below to find the section you are looking for.***
+
+**What personal information do I process?** When you visit, use, or navigate my Services, I may process personal information depending on how you interact with me and the Services, the choices you make, and the products and features you use. Learn more about [personal information you disclose to us](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#personalinfo).
+
+**Do I process any sensitive personal information?** Some of the information may be considered "special" or "sensitive" in certain jurisdictions, for example your racial or ethnic origins, sexual orientation, and religious beliefs. I may process sensitive personal information when necessary with your consent or as otherwise permitted by applicable law. Learn more about [sensitive information I process](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#sensitiveinfo).
+
+**Do I collect any information from third parties?** I do not collect any information from third parties.
+
+**How do I process your information?** I process your information to provide, improve, and administer my Services, communicate with you, for security and fraud prevention, and to comply with law. I may also process your information for other purposes with your consent. I process your information only when I have a valid legal reason to do so. Learn more about [how I process your information](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#infouse).
+
+**In what situations and with which parties do I share personal information?** I may share information in specific situations and with specific third parties. Learn more about [when and with whom I share your personal information](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#whoshare).
+
+**How do I keep your information safe?** I have adequate organizational and technical processes and procedures in place to protect your personal information. However, no electronic transmission over the internet or information storage technology can be guaranteed to be 100% secure, so I cannot promise or guarantee that hackers, cybercriminals, or other unauthorized third parties will not be able to defeat my security and improperly collect, access, steal, or modify your information. Learn more about [how I keep your information safe](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#infosafe).
+
+**What are your rights?** Depending on where you are located geographically, the applicable privacy law may mean you have certain rights regarding your personal information. Learn more about [your privacy rights](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#privacyrights).
+
+**How do you exercise your rights?** The easiest way to exercise your rights is by visiting [https://pilot-dashboard.e57.dk/request-all-data](https://pilot-dashboard.e57.dk/request-all-data), or by contacting us. I will consider and act upon any request in accordance with applicable data protection laws.
+
+Want to learn more about what I do with any information I collect? [Review the Privacy Notice in full](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#toc).
+
+## **TABLE OF CONTENTS**
+
+[1\. WHAT INFORMATION DO I COLLECT?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#infocollect)  
+[2\. HOW DO I PROCESS YOUR INFORMATION?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#infouse)  
+[3\. WHAT LEGAL BASES DO I RELY ON TO PROCESS YOUR PERSONAL INFORMATION?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#legalbases)  
+[4\. WHEN AND WITH WHOM DO I SHARE YOUR PERSONAL INFORMATION?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#whoshare)  
+[5\. DO I USE COOKIES AND OTHER TRACKING TECHNOLOGIES?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#cookies)  
+[6\. DO I OFFER ARTIFICIAL INTELLIGENCE-BASED PRODUCTS?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#ai)  
+[7\. HOW LONG DO I KEEP YOUR INFORMATION?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#inforetain)  
+[8\. HOW DO I KEEP YOUR INFORMATION SAFE?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#infosafe)  
+[9\. DO I COLLECT INFORMATION FROM MINORS?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#infominors)  
+[10\. WHAT ARE YOUR PRIVACY RIGHTS?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#privacyrights)  
+[11\. CONTROLS FOR DO-NOT-TRACK FEATURES](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#DNT)  
+[12\. DO UNITED STATES RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#uslaws)  
+[13\. AI USE & NO PERSONAL DATA](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#clausea)  
+[14\. USER DOCUMENT UPLOADS](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#clauseb)  
+[15\. LOCAL STORAGE USE](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#clausec)  
+[16\. DO I MAKE UPDATES TO THIS NOTICE?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#policyupdates)  
+[17\. HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#contact)  
+[18\. HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA I COLLECT FROM YOU?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#request)
+
+## **1\. WHAT INFORMATION DO I COLLECT?**
+
+### **Personal information you disclose to us**
+
+***In Short: I** collect personal information that you provide to us.*
+
+I collect personal information that you voluntarily provide to me when you register on the Services, express an interest in obtaining information about me or my products and Services, when you participate in activities on the Services, or otherwise when you contact us.
+
+**Personal Information Provided by You.** The personal information that I collect depends on the context of your interactions with me and the Services, the choices you make, and the products and features you use. The personal information I collect may include the following:
+
+* names  
+* email addresses  
+* usernames  
+* passwords  
+* uploaded photos and documents (such as pilot licenses, aircraft documents, or other files)
+
+**Sensitive Information.** When necessary, with your consent or as otherwise permitted by applicable law, I process the following categories of sensitive information:
+
+* health data  
+* social security numbers or other government identifiers
+
+All personal information that you provide to me must be true, complete, and accurate, and you must notify me of any changes to such personal information.
+
+## **2\. HOW DO I PROCESS YOUR INFORMATION?**
+
+***In Short: I** process your information to provide, improve, and administer my Services, communicate with you, for security and fraud prevention, and to comply with law. I process the personal information for the following purposes listed below. I may also process your information for other purposes only with your prior explicit consent.*
+
+**I process your personal information for a variety of reasons, depending on how you interact with my Services, including:**
+
+* **To facilitate account creation and authentication and otherwise manage user accounts. I** may process your information so you can create and log in to your account, as well as keep your account in working order.  
+* **To deliver and facilitate delivery of services to the user. I** may process your information to provide you with the requested service.  
+* **To respond to user inquiries/offer support to users. I** may process your information to respond to your inquiries and solve any potential issues you might have with the requested service.  
+* **To send administrative information to you. I** may process your information to send you details about my products and services, changes to my terms and policies, and other similar information.  
+* **To protect my Services.** I may process your information as part of my efforts to keep my Services safe and secure, including fraud monitoring and prevention.  
+* **To identify usage trends.** I may process information about how you use my Services to better understand how they are being used so I can improve them.  
+* **To save or protect an individual's vital interest.** I may process your information when necessary to save or protect an individual’s vital interest, such as to prevent harm.
+
+## **3\. WHAT LEGAL BASES DO I RELY ON TO PROCESS YOUR INFORMATION?**
+
+***In Short: I** only process your personal information when I believe it is necessary and I have a valid legal reason (i.e., legal basis) to do so under applicable law, like with your consent, to comply with laws, to provide you with services to enter into or fulfill my contractual obligations, to protect your rights, or to fulfill my legitimate business interests.*
+
+***If you are located in the EU or UK, this section applies to you.***
+
+The General Data Protection Regulation (GDPR) and UK GDPR require me to explain the valid legal bases I rely on in order to process your personal information. As such, I may rely on the following legal bases to process your personal information:
+
+* **Consent. I** may process your information if you have given me permission (i.e., consent) to use your personal information for a specific purpose. You can withdraw your consent at any time. Learn more about [withdrawing your consent](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#withdrawconsent).  
+* **Performance of a Contract.** I may process your personal information when I believe it is necessary to fulfill my contractual obligations to you, including providing my Services or at your request prior to entering into a contract with you.  
+* **Legitimate Interests.** I may process your information when I believe it is reasonably necessary to achieve my legitimate business interests and those interests do not outweigh your interests and fundamental rights and freedoms. For example, I may process your personal information for some of the purposes described in order to:  
+* Analyze how my Services are used so I can improve them to engage and retain users  
+* Diagnose problems and/or prevent fraudulent activities  
+* **Legal Obligations.** I may process your information where I believe it is necessary for compliance with my legal obligations, such as to cooperate with a law enforcement body or regulatory agency, exercise or defend my legal rights, or disclose your information as evidence in litigation in which I are involved.  
+* **Vital Interests.** I may process your information where I believe it is necessary to protect your vital interests or the vital interests of a third party, such as situations involving potential threats to the safety of any person.
+
+***If you are located in Canada, this section applies to you.***
+
+I may process your information if you have given me specific permission (i.e., express consent) to use your personal information for a specific purpose, or in situations where your permission can be inferred (i.e., implied consent). You can [withdraw your consent](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#withdrawconsent) at any time.
+
+In some exceptional cases, I may be legally permitted under applicable law to process your information without your consent, including, for example:
+
+* If collection is clearly in the interests of an individual and consent cannot be obtained in a timely way  
+* For investigations and fraud detection and prevention  
+* For business transactions provided certain conditions are met  
+* If it is contained in a witness statement and the collection is necessary to assess, process, or settle an insurance claim  
+* For identifying injured, ill, or deceased persons and communicating with next of kin  
+* If I have reasonable grounds to believe an individual has been, is, or may be victim of financial abuse  
+* If it is reasonable to expect collection and use with consent would compromise the availability or the accuracy of the information and the collection is reasonable for purposes related to investigating a breach of an agreement or a contravention of the laws of Canada or a province  
+* If disclosure is required to comply with a subpoena, warrant, court order, or rules of the court relating to the production of records  
+* If it was produced by an individual in the course of their employment, business, or profession and the collection is consistent with the purposes for which the information was produced  
+* If the collection is solely for journalistic, artistic, or literary purposes  
+* If the information is publicly available and is specified by the regulations  
+* I may disclose de-identified information for approved research or statistics projects, subject to ethics oversight and confidentiality commitments
+
+## **4\. WHEN AND WITH WHOM DO I SHARE YOUR PERSONAL INFORMATION?**
+
+***In Short:** I may share information in specific situations described in this section and/or with the following third parties.*
+
+I may need to share your personal information in the following situations:
+
+* **Business Transfers.** I may share or transfer your information in connection with, or during negotiations of, any merger, sale of company assets, financing, or acquisition of all or a portion of my business to another company.
+
+## **5\. DO I USE COOKIES AND OTHER TRACKING TECHNOLOGIES?**
+
+***In Short:** I may use cookies and other tracking technologies to collect and store your information.*
+
+I may use cookies and similar tracking technologies (like web beacons and pixels) to gather information when you interact with my Services. Some online tracking technologies help me maintain the security of my Services and your account, prevent crashes, fix bugs, save your preferences, and assist with basic site functions.
+
+I also permit third parties and service providers to use online tracking technologies on my Services for analytics and advertising, including to help manage and display advertisements, to tailor advertisements to your interests, or to send abandoned shopping cart reminders (depending on your communication preferences). The third parties and service providers use their technology to provide advertising about products and services tailored to your interests which may appear either on my Services or on other websites.
+
+To the extent these online tracking technologies are deemed to be a "sale"/"sharing" (which includes targeted advertising, as defined under the applicable laws) under applicable US state laws, you can opt out of these online tracking technologies by submitting a request as described below under section "[DO UNITED STATES RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#uslaws)"
+
+Specific information about how I use such technologies and how you can refuse certain cookies is set out in my Cookie Notice.
+
+## **6\. DO I OFFER ARTIFICIAL INTELLIGENCE-BASED PRODUCTS?**
+
+***In Short:** I offer products, features, or tools powered by artificial intelligence, machine learning, or similar technologies.*
+
+As part of my Services, I offer products, features, or tools powered by artificial intelligence, machine learning, or similar technologies (collectively, "AI Products"). These tools are designed to enhance your experience and provide you with innovative solutions. The terms in this Privacy Notice govern your use of the AI Products within my Services.
+
+**Use of AI Technologies**
+
+I provide the AI Products through third-party service providers ("AI Service Providers"), including OpenAI. As outlined in this Privacy Notice, your input, output, and personal information will be shared with and processed by these AI Service Providers to enable your use of my AI Products for purposes outlined in "[WHAT LEGAL BASES DO I RELY ON TO PROCESS YOUR PERSONAL INFORMATION?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#legalbases)" You must not use the AI Products in any way that violates the terms or policies of any AI Service Provider.
+
+**My AI Products**
+
+My AI Products are designed for the following functions:
+
+* Weather analysis  
+* Flight safety suggestions  
+* Preflight advice  
+* Contextual recommendations
+
+**How I Process Your Data Using AI**
+
+All personal information processed using my AI Products is handled in line with my Privacy Notice and my agreement with third parties. This ensures high security and safeguards your personal information throughout the process, giving you peace of mind about your data's safety.
+
+**How to Opt Out**
+
+I believe in giving you the power to decide how your data is used. To opt out, you can:
+
+* No user personal information is processed by my AI services. Opt-out is not necessary.
+
+## **7\. HOW LONG DO I KEEP YOUR INFORMATION?**
+
+***In Short: I** keep your information for as long as necessary to fulfill the purposes outlined in this Privacy Notice unless otherwise required by law.*
+
+I will only keep your personal information for as long as it is necessary for the purposes set out in this Privacy Notice, unless a longer retention period is required or permitted by law (such as tax, accounting, or other legal requirements). No purpose in this notice will require me keeping your personal information for longer than the period of time in which users have an account with us.
+
+When I have no ongoing legitimate business need to process your personal information, I will either delete or anonymize such information, or, if this is not possible (for example, because your personal information has been stored in backup archives), then I will securely store your personal information and isolate it from any further processing until deletion is possible.
+
+## **8\. HOW DO I KEEP YOUR INFORMATION SAFE?**
+
+***In Short: I** aim to protect your personal information through a system of organizational and technical security measures.*
+
+I have implemented appropriate and reasonable technical and organizational security measures designed to protect the security of any personal information I process. However, despite my safeguards and efforts to secure your information, no electronic transmission over the Internet or information storage technology can be guaranteed to be 100% secure, so I cannot promise or guarantee that hackers, cybercriminals, or other unauthorized third parties will not be able to defeat my security and improperly collect, access, steal, or modify your information. Although I will do my best to protect your personal information, transmission of personal information to and from my Services is at your own risk. You should only access the Services within a secure environment.
+
+## **9\. DO I COLLECT INFORMATION FROM MINORS?**
+
+***In Short:** I do not knowingly collect data from or market to children under 18 years of age or the equivalent age as specified by law in your jurisdiction.*
+
+I do not knowingly collect, solicit data from, or market to children under 18 years of age or the equivalent age as specified by law in your jurisdiction, nor do I knowingly sell such personal information. By using the Services, you represent that you are at least 18 or the equivalent age as specified by law in your jurisdiction or that you are the parent or guardian of such a minor and consent to such minor dependent’s use of the Services. If I learn that personal information from users less than 18 years of age or the equivalent age as specified by law in your jurisdiction has been collected, I will deactivate the account and take reasonable measures to promptly delete such data from my records. If you become aware of any data I may have collected from children under age 18 or the equivalent age as specified by law in your jurisdiction, please contact me at lhrh.privat@gmail.com.
+
+## **10\. WHAT ARE YOUR PRIVACY RIGHTS?**
+
+***In Short:** Depending on your state of residence in the US or in some regions, such as the European Economic Area (EEA), United Kingdom (UK), Switzerland, and Canada, you have rights that allow you greater access to and control over your personal information. You may review, change, or terminate your account at any time, depending on your country, province, or state of residence.*
+
+In some regions (like the EEA, UK, Switzerland, and Canada), you have certain rights under applicable data protection laws. These may include the right (i) to request access and obtain a copy of your personal information, (ii) to request rectification or erasure; (iii) to restrict the processing of your personal information; (iv) if applicable, to data portability; and (v) not to be subject to automated decision-making. If a decision that produces legal or similarly significant effects is made solely by automated means, I will inform you, explain the main factors, and offer a simple way to request human review. In certain circumstances, you may also have the right to object to the processing of your personal information. You can make such a request by contacting me by using the contact details provided in the section "[HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#contact)" below.
+
+I will consider and act upon any request in accordance with applicable data protection laws.  
+   
+If you are located in the EEA or UK and you believe I are unlawfully processing your personal information, you also have the right to complain to your [Member State data protection authority](https://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm) or [UK data protection authority](https://ico.org.uk/make-a-complaint/data-protection-complaints/data-protection-complaints/).
+
+If you are located in Switzerland, you may contact the [Federal Data Protection and Information Commissioner](https://www.edoeb.admin.ch/edoeb/en/home.html).
+
+**Withdrawing your consent:** If I are relying on your consent to process your personal information, which may be express and/or implied consent depending on the applicable law, you have the right to withdraw your consent at any time. You can withdraw your consent at any time by contacting me by using the contact details provided in the section "[HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#contact)" below.
+
+However, please note that this will not affect the lawfulness of the processing before its withdrawal nor, when applicable law allows, will it affect the processing of your personal information conducted in reliance on lawful processing grounds other than consent.
+
+### **Account Information**
+
+If you would at any time like to review or change the information in your account or terminate your account, you can:
+
+* Log in to your account settings and update your user account.
+
+Upon your request to terminate your account, I will deactivate or delete your account and information from my active databases. However, I may retain some information in my files to prevent fraud, troubleshoot problems, assist with any investigations, enforce my legal terms and/or comply with applicable legal requirements.
+
+**Cookies and similar technologies:** Most Web browsers are set to accept cookies by default. If you prefer, you can usually choose to set your browser to remove cookies and to reject cookies. If you choose to remove cookies or reject cookies, this could affect certain features or services of my Services.
+
+If you have questions or comments about your privacy rights, you may email me at lhrh.privat@gmail.com.
+
+## **11\. CONTROLS FOR DO-NOT-TRACK FEATURES**
+
+Most web browsers and some mobile operating systems and mobile applications include a Do-Not-Track ("DNT") feature or setting you can activate to signal your privacy preference not to have data about your online browsing activities monitored and collected. At this stage, no uniform technology standard for recognizing and implementing DNT signals has been finalized. As such, I do not currently respond to DNT browser signals or any other mechanism that automatically communicates your choice not to be tracked online. If a standard for online tracking is adopted that I must follow in the future, I will inform you about that practice in a revised version of this Privacy Notice.
+
+California law requires me to let you know how I respond to web browser DNT signals. Because there currently is not an industry or legal standard for recognizing or honoring DNT signals, I do not respond to them at this time.
+
+## **12\. DO UNITED STATES RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?**
+
+***In Short:** If you are a resident of, you may have the right to request access to and receive details about the personal information I maintain about you and how I have processed it, correct inaccuracies, get a copy of, or delete your personal information. You may also have the right to withdraw your consent to my processing of your personal information. These rights may be limited in some circumstances by applicable law. More information is provided below.*
+
+### **Categories of Personal Information I Collect**
+
+The table below shows the categories of personal information I have collected in the past twelve (12) months. The table includes illustrative examples of each category and does not reflect the personal information I collect from you. For a comprehensive inventory of all personal information I process, please refer to the section "[WHAT INFORMATION DO I COLLECT?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#infocollect)"
+
+| Category | Examples | Collected |
+| :---- | :---- | ----- |
+| A. Identifiers | Contact details, such as real name, alias, postal address, telephone or mobile contact number, unique personal identifier, online identifier, Internet Protocol address, email address, and account name |  YES  |
+
+| B. Protected classification characteristics under state or federal law | Gender, age, date of birth, race and ethnicity, national origin, marital status, and other demographic data |  NO  |
+| :---- | :---- | :---: |
+| C. Commercial information | Transaction information, purchase history, financial details, and payment information |  NO  |
+| D. Biometric information | Fingerprints and voiceprints |  NO  |
+| E. Internet or other similar network activity | Browsing history, search history, online behavior, interest data, and interactions with my and other websites, applications, systems, and advertisements |  NO  |
+| F. Geolocation data | Device location |  NO  |
+| G. Audio, electronic, sensory, or similar information | Images and audio, video or call recordings created in connection with my business activities |  NO  |
+| H. Professional or employment-related information | Business contact details in order to provide you my Services at a business level or job title, work history, and professional qualifications if you apply for a job with us |  NO  |
+| I. Education Information | Student records and directory information |  NO  |
+| J. Inferences drawn from collected personal information | Inferences drawn from any of the collected personal information listed above to create a profile or summary about, for example, an individual’s preferences and characteristics |  NO  |
+| K. Sensitive personal Information | Account login information |  YES  |
+
+I only collect sensitive personal information, as defined by applicable privacy laws or the purposes allowed by law or with your consent. Sensitive personal information may be used, or disclosed to a service provider or contractor, for additional, specified purposes. You may have the right to limit the use or disclosure of your sensitive personal information. I do not collect or process sensitive personal information for the purpose of inferring characteristics about you.
+
+I may also collect other personal information outside of these categories through instances where you interact with me in person, online, or by phone or mail in the context of:
+
+* Receiving help through my customer support channels;  
+* Participation in customer surveys or contests; and  
+* Facilitation in the delivery of my Services and to respond to your inquiries.
+
+I will use and retain the collected personal information as needed to provide the Services or for:
+
+* Category A \- As long as the user has an account with us  
+* Category K \- As long as the user has an account with us
+
+### **Sources of Personal Information**
+
+Learn more about the sources of personal information I collect in "[WHAT INFORMATION DO I COLLECT?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#infocollect)"
+
+### **How I Use and Share Personal Information**
+
+Learn more about how I use your personal information in the section, "[HOW DO I PROCESS YOUR INFORMATION?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#infouse)"
+
+**Will your information be shared with anyone else?**
+
+I may disclose your personal information with my service providers pursuant to a written contract between me and each service provider. Learn more about how I disclose personal information to in the section, "[WHEN AND WITH WHOM DO I SHARE YOUR PERSONAL INFORMATION?](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/privacy-policy#whoshare)"
+
+I may use your personal information for my own business purposes, such as for undertaking internal research for technological development and demonstration. This is not considered to be "selling" of your personal information.
+
+I have not disclosed, sold, or shared any personal information to third parties for a business or commercial purpose in the preceding twelve (12) months. I will not sell or share personal information in the future belonging to website visitors, users, and other consumers.
+
+### **Your Rights**
+
+You have rights under certain US state data protection laws. However, these rights are not absolute, and in certain cases, I may decline your request as permitted by law. These rights include:
+
+* **Right to know** whether or not I are processing your personal data  
+* **Right to access** your personal data  
+* **Right to correct** inaccuracies in your personal data  
+* **Right to request** the deletion of your personal data  
+* **Right to obtain a copy** of the personal data you previously shared with us  
+* **Right to non-discrimination** for exercising your rights  
+* **Right to opt out** of the processing of your personal data if it is used for targeted advertising, the sale of personal data, or profiling in furtherance of decisions that produce legal or similarly significant effects ("profiling")
+
+### **How to Exercise Your Rights**
+
+To exercise these rights, you can contact me by visiting [https://pilot-dashboard.e57.dk/request-all-data](https://pilot-dashboard.e57.dk/request-all-data), by emailing me at lhrh.privat@gmail.com, or by referring to the contact details at the bottom of this document.
+
+Under certain US state data protection laws, you can designate an authorized agent to make a request on your behalf. I may deny a request from an authorized agent that does not submit proof that they have been validly authorized to act on your behalf in accordance with applicable laws.
+
+### **Request Verification**
+
+Upon receiving your request, I will need to verify your identity to determine you are the same person about whom I have the information in my system. I will only use personal information provided in your request to verify your identity or authority to make the request. However, if I cannot verify your identity from the information already maintained by us, I may request that you provide additional information for the purposes of verifying your identity and for security or fraud-prevention purposes.
+
+If you submit the request through an authorized agent, I may need to collect additional information to verify your identity before processing your request and the agent will need to provide a written and signed permission from you to submit such request on your behalf.
+
+## **13\. AI USE & NO PERSONAL DATA**
+
+My AI features only process public or non-personal data (such as weather or NOTAMs). Your personal information is never used for AI analysis, and no user data is shared with any AI providers.
+
+## **14\. USER DOCUMENT UPLOADS**
+
+When uploading documents (such as licenses or certificates), please remove or redact unnecessary sensitive information. I take steps to protect uploaded files, but you are responsible for the data you choose to submit.
+
+## **15\. LOCAL STORAGE USE**
+
+I use browser local storage to store your preferences and login tokens. No tracking or advertising cookies are used.
+
+## **16\. DO I MAKE UPDATES TO THIS NOTICE?**
+
+***In Short:** Yes, I will update this notice as necessary to stay compliant with relevant laws.*
+
+I may update this Privacy Notice from time to time. The updated version will be indicated by an updated "Revised" date at the top of this Privacy Notice. If I make material changes to this Privacy Notice, I may notify you either by prominently posting a notice of such changes or by directly sending you a notification. I encourage you to review this Privacy Notice frequently to be informed of how I are protecting your information.
+
+## **17\. HOW CAN YOU CONTACT US ABOUT THIS NOTICE?**
+
+If you have questions or comments about this notice, you may email me at lhrh.privat@gmail.com or contact me by post at:
+
+Lucas Hjort Rahr Hartung  
+Egeparken 57  
+Rødekro, Syddanmark 6230  
+Denmark
+
+## **18\. HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA I COLLECT FROM YOU?**
+
+You have the right to request access to the personal information I collect from you, details about how I have processed it, correct inaccuracies, or delete your personal information. You may also have the right to withdraw your consent to my processing of your personal information. These rights may be limited in some circumstances by applicable law. To request to review, update, or delete your personal information, please visit: [https://pilot-dashboard.e57.dk/request-all-data](https://pilot-dashboard.e57.dk/request-all-data).  
+</script>
+      </main>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script>
+      const md = document.getElementById("privacyMarkdown").textContent;
+      document.getElementById("privacyContent").innerHTML = marked.parse(md);
+    </script>
+    <script src="assets/js/darkmode.js"></script>
+  </body>
+</html>

--- a/signup.html
+++ b/signup.html
@@ -72,6 +72,8 @@
               placeholder="Confirm Password"
               required />
 
+            <p style="font-size: 13px; margin-top: 4px;">By signing up you agree to our <a href="/terms-of-service">Terms of Service</a> and <a href="/privacy-notice">Privacy Notice</a>.</p>
+
             <button type="submit">Sign Up</button>
 
             <div class="link">

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Terms of Service - Pilot Dashboard</title>
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/layout.css" />
+    <link rel="stylesheet" href="assets/css/nav.css" />
+    <link rel="stylesheet" href="assets/css/darkmode.css" />
+    <link rel="stylesheet" href="assets/css/about.css" />
+    <script defer src="assets/js/header.js"></script>
+  </head>
+  <body>
+    <div class="scaling-wrapper">
+      <main>
+        <h1>Terms of Service</h1>
+        <div id="versionRow">
+          Last updated: <span id="lastUpdated">June 01, 2025</span>
+        </div>
+        <div id="tosContent"></div>
+        <script id="tosMarkdown" type="text/plain">
+# **TERMS OF SERVICE**
+
+**Last updated** **June 01, 2025**
+
+## **AGREEMENT TO OUR LEGAL TERMS**
+
+I am Lucas Hjort Rahr Hartung ("**I**," "**me**," "**my**"), the creator and maintainer of Pilot Dashboard based in Denmark.
+
+I operate the website [https://pilot-dashboard.e57.dk/](https://pilot-dashboard.e57.dk/) (the "**Site**") and provide related services that are directly managed by me and refer to these legal terms (the "Services").
+
+Pilot Dashboard is a free, open-source web app designed to help pilots plan, log, and analyze their flights. It is built with a focus on simplicity, usability, and data privacy.
+
+You can contact me by email at lhrh.privat@gmail.com.
+
+These Legal Terms constitute a legally binding agreement made between you, whether personally or on behalf of an entity ("**you**"), and Lucas Hjort Rahr Hartung, concerning your access to and use of the Services. You agree that by accessing the Services, you have read, understood, and agreed to be bound by all of these Legal Terms. IF YOU DO NOT AGREE WITH ALL OF THESE LEGAL TERMS, THEN YOU ARE EXPRESSLY PROHIBITED FROM USING THE SERVICES AND YOU MUST DISCONTINUE USE IMMEDIATELY.
+
+Supplemental terms and conditions or documents that may be posted on the Services from time to time are hereby expressly incorporated herein by reference. I reserve the right, in my sole discretion, to make changes or modifications to these Legal Terms from time to time. I will alert you about any changes by updating the "Last updated" date of these Legal Terms, and you waive any right to receive specific notice of each such change. It is your responsibility to periodically review these Legal Terms to stay informed of updates. You will be subject to, and will be deemed to have been made aware of and to have accepted, the changes in any revised Legal Terms by your continued use of the Services after the date such revised Legal Terms are posted.
+
+All users who are minors in the jurisdiction in which they reside (generally under the age of 18\) must have the permission of, and be directly supervised by, their parent or guardian to use the Services. If you are a minor, you must have your parent or guardian read and agree to these Legal Terms prior to you using the Services.
+
+I recommend that you print a copy of these Legal Terms for your records.
+
+## **TABLE OF CONTENTS**
+
+[1\. OUR SERVICES](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#services)  
+[2\. INTELLECTUAL PROPERTY RIGHTS](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#ip)  
+[3\. USER REPRESENTATIONS](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#userreps)  
+[4\. USER REGISTRATION](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#userreg)  
+[5\. PURCHASES AND PAYMENT](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#purchases)  
+[6\. PROHIBITED ACTIVITIES](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#prohibited)  
+[7\. USER GENERATED CONTRIBUTIONS](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#ugc)  
+[8\. CONTRIBUTION LICENSE](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#license)  
+[9\. THIRD-PARTY WEBSITES AND CONTENT](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#thirdparty)  
+[10\. SERVICES MANAGEMENT](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#sitemanage)  
+[11\. PRIVACY POLICY](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#ppno)  
+[12\. TERM AND TERMINATION](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#terms)  
+[13\. MODIFICATIONS AND INTERRUPTIONS](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#modifications)  
+[14\. GOVERNING LAW](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#law)  
+[15\. DISPUTE RESOLUTION](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#disputes)  
+[16\. CORRECTIONS](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#corrections)  
+[17\. DISCLAIMER](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#disclaimer)  
+[18\. LIMITATIONS OF LIABILITY](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#liability)  
+[19\. INDEMNIFICATION](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#indemnification)  
+[20\. USER DATA](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#userdata)  
+[21\. ELECTRONIC COMMUNICATIONS, TRANSACTIONS, AND SIGNATURES](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#electronic)  
+[22\. CALIFORNIA USERS AND RESIDENTS](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#california)  
+[23\. MISCELLANEOUS](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#misc)  
+[24\. API USAGE AND ACCESS](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#addclause)  
+[25\. CONTACT US](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#contact)
+
+## **1\. OUR SERVICES**
+
+The information provided when using the Services is not intended for distribution to or use by any person or entity in any jurisdiction or country where such distribution or use would be contrary to law or regulation or which would subject me to any registration requirement within such jurisdiction or country. Accordingly, those persons who choose to access the Services from other locations do so on their own initiative and are solely responsible for compliance with local laws, if and to the extent local laws are applicable.
+
+The Services are not tailored to comply with industry-specific regulations (Health Insurance Portability and Accountability Act (HIPAA), Federal Information Security Management Act (FISMA), etc.), so if your interactions would be subjected to such laws, you may not use the Services. You may not use the Services in a way that would violate the Gramm-Leach-Bliley Act (GLBA).
+
+## **2\. INTELLECTUAL PROPERTY RIGHTS**
+
+### **My intellectual property**
+
+I am the owner or the licensee of all intellectual property rights in my Services, including all source code, databases, functionality, software, website designs, audio, video, text, photographs, and graphics in the Services (collectively, the "Content"), as well as the trademarks, service marks, and logos contained therein (the "Marks").
+
+My Content and Marks are protected by copyright and trademark laws (and variome other intellectual property rights and unfair competition laws) and treaties in the United States and around the world.
+
+The Content and Marks are provided in or through the Services "AS IS" for your personal, non-commercial use or internal business purpose only.
+
+### **Your use of my Services**
+
+Subject to your compliance with these Legal Terms, including the "[PROHIBITED ACTIVITIES](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#prohibited)" section below, I grant you a non-exclusive, non-transferable, revocable license to:
+
+* access the Services; and  
+* download or print a copy of any portion of the Content to which you have properly gained access,
+
+solely for your personal, non-commercial use or internal business purpose.
+
+Except as set out in this section or elsewhere in my Legal Terms, no part of the Services and no Content or Marks may be copied, reproduced, aggregated, republished, uploaded, posted, publicly displayed, encoded, translated, transmitted, distributed, sold, licensed, or otherwise exploited for any commercial purpose whatsoever, without my express prior written permission.
+
+If you wish to make any use of the Services, Content, or Marks other than as set out in this section or elsewhere in my Legal Terms, please address your request to: lhrh.privat@gmail.com. If I ever grant you the permission to post, reproduce, or publicly display any part of my Services or Content, you must identify me as the owners or licensors of the Services, Content, or Marks and ensure that any copyright or proprietary notice appears or is visible on posting, reproducing, or displaying my Content.
+
+I reserve all rights not expressly granted to you in and to the Services, Content, and Marks.
+
+Any breach of these Intellectual Property Rights will constitute a material breach of my Legal Terms and your right to use my Services will terminate immediately.
+
+### **Your submissions and contributions**
+
+Please review this section and the "[PROHIBITED ACTIVITIES](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#prohibited)" section carefully prior to using my Services to understand the (a) rights you give me and (b) obligations you have when you post or upload any content through the Services.
+
+**Submissions:** By directly sending me any question, comment, suggestion, idea, feedback, or other information about the Services ("Submissions"), you agree to assign to me all intellectual property rights in such Submission. You agree that I shall own this Submission and be entitled to its unrestricted use and dissemination for any lawful purpose, commercial or otherwise, without acknowledgment or compensation to you.
+
+**Contributions:** The Services may invite you to chat, contribute to, or participate in blogs, message boards, online forums, and other functionality during which you may create, submit, post, display, transmit, publish, distribute, or broadcast content and materials to me or through the Services, including but not limited to text, writings, video, audio, photographs, music, graphics, comments, reviews, rating suggestions, personal information, or other material ("Contributions"). Any Submission that is publicly posted shall also be treated as a Contribution.
+
+You understand that Contributions may be viewable by other users of the Services and possibly through third-party websites.
+
+**When you post Contributions, you grant me a license (including use of your name, trademarks, and logos):** By posting any Contributions, you grant me an unrestricted, unlimited, irrevocable, perpetual, non-exclusive, transferable, royalty-free, fully-paid, worldwide right, and license to: use, copy, reproduce, distribute, sell, resell, publish, broadcast, retitle, store, publicly perform, publicly display, reformat, translate, excerpt (in whole or in part), and exploit your Contributions (including, without limitation, your image, name, and voice) for any purpose, commercial, advertising, or otherwise, to prepare derivative works of, or incorporate into other works, your Contributions, and to sublicense the licenses granted in this section. My use and distribution may occur in any media formats and through any media channels.
+
+This license includes my use of your name, company name, and franchise name, as applicable, and any of the trademarks, service marks, trade names, logos, and personal and commercial images you provide.
+
+**You are responsible for what you post or upload:** By sending me Submissions and/or posting Contributions through any part of the Services or making Contributions accessible through the Services by linking your account through the Services to any of your social networking accounts, you:
+
+* confirm that you have read and agree with my "[PROHIBITED ACTIVITIES](https://app.termly.io/dashboard/website/85ebc085-8900-4e17-968d-cbb02f23ee53/terms-of-service#prohibited)" and will not post, send, publish, upload, or transmit through the Services any Submission nor post any Contribution that is illegal, harassing, hateful, harmful, defamatory, obscene, bullying, abusive, discriminatory, threatening to any person or group, sexually explicit, false, inaccurate, deceitful, or misleading;  
+* to the extent permissible by applicable law, waive any and all moral rights to any such Submission and/or Contribution;  
+* warrant that any such Submission and/or Contributions are original to you or that you have the necessary rights and licenses to submit such Submissions and/or Contributions and that you have full authority to grant me the above-mentioned rights in relation to your Submissions and/or Contributions; and  
+* warrant and represent that your Submissions and/or Contributions do not constitute confidential information.
+
+You are solely responsible for your Submissions and/or Contributions and you expressly agree to reimburse me for any and all losses that I may suffer because of your breach of (a) this section, (b) any third party’s intellectual property rights, or (c) applicable law.
+
+**I may remove or edit your Content:** Although I have no obligation to monitor any Contributions, I shall have the right to remove or edit any Contributions at any time without notice if in my reasonable opinion I consider such Contributions harmful or in breach of these Legal Terms. If I remove or edit any such Contributions, I may also suspend or disable your account and report you to the authorities.
+
+## **3\. USER REPRESENTATIONS**
+
+By using the Services, you represent and warrant that: (1) all registration information you submit will be true, accurate, current, and complete; (2) you will maintain the accuracy of such information and promptly update such registration information as necessary; (3) you have the legal capacity and you agree to comply with these Legal Terms; (4) you are not a minor in the jurisdiction in which you reside, or if a minor, you have received parental permission to use the Services; (5) you will not access the Services through automated or non-human means, whether through a bot, script or otherwise; (6) you will not use the Services for any illegal or unauthorized purpose; and (7) your use of the Services will not violate any applicable law or regulation.
+
+If you provide any information that is untrue, inaccurate, not current, or incomplete, I have the right to suspend or terminate your account and refuse any and all current or future use of the Services (or any portion thereof).
+
+## **4\. USER REGISTRATION**
+
+You may be required to register to use the Services. You agree to keep your password confidential and will be responsible for all use of your account and password. I reserve the right to remove, reclaim, or change a username you select if I determine, in my sole discretion, that such username is inappropriate, obscene, or otherwise objectionable.
+
+## **5\. PURCHASES AND PAYMENT**
+
+I accept the following forms of payment:
+
+\-  PayPal
+
+You agree to provide current, complete, and accurate purchase and account information for all purchases made via the Services. You further agree to promptly update account and payment information, including email address, payment method, and payment card expiration date, so that I can complete your transactions and contact you as needed. Sales tax will be added to the price of purchases as deemed required by us. I may change prices at any time. All payments shall be in US dollars.
+
+You agree to pay all charges at the prices then in effect for your purchases and any applicable shipping fees, and you authorize me to charge your chosen payment provider for any such amounts upon placing your order. I reserve the right to correct any errors or mistakes in pricing, even if I have already requested or received payment.
+
+I reserve the right to refuse any order placed through the Services. I may, in my sole discretion, limit or cancel quantities purchased per person, per household, or per order. These restrictions may include orders placed by or under the same customer account, the same payment method, and/or orders that use the same billing or shipping address. I reserve the right to limit or prohibit orders that, in my sole judgment, appear to be placed by dealers, resellers, or distributors.
+
+## **6\. PROHIBITED ACTIVITIES**
+
+You may not access or use the Services for any purpose other than that for which I make the Services available. The Services may not be used in connection with any commercial endeavors except those that are specifically endorsed or approved by us.
+
+As a user of the Services, you agree not to:
+
+* Systematically retrieve data or other content from the Services to create or compile, directly or indirectly, a collection, compilation, database, or directory without written permission from us.  
+* Trick, defraud, or mislead me and other users, especially in any attempt to learn sensitive account information such as user passwords.  
+* Circumvent, disable, or otherwise interfere with security-related features of the Services, including features that prevent or restrict the use or copying of any Content or enforce limitations on the use of the Services and/or the Content contained therein.  
+* Disparage, tarnish, or otherwise harm, in my opinion, me and/or the Services.  
+* Use any information obtained from the Services in order to harass, abuse, or harm another person.  
+* Make improper use of my support services or submit false reports of abuse or misconduct.  
+* Use the Services in a manner inconsistent with any applicable laws or regulations.  
+* Engage in unauthorized framing of or linking to the Services.  
+* Upload or transmit (or attempt to upload or to transmit) viruses, Trojan horses, or other material, including excessive use of capital letters and spamming (continuome posting of repetitive text), that interferes with any party’s uninterrupted use and enjoyment of the Services or modifies, impairs, disrupts, alters, or interferes with the use, features, functions, operation, or maintenance of the Services.  
+* Engage in any automated use of the system, such as using scripts to send comments or messages, or using any data mining, robots, or similar data gathering and extraction tools.  
+* Delete the copyright or other proprietary rights notice from any Content.  
+* Attempt to impersonate another user or person or use the username of another user.  
+* Upload or transmit (or attempt to upload or to transmit) any material that acts as a passive or active information collection or transmission mechanism, including without limitation, clear graphics interchange formats ("gifs"), 1×1 pixels, web bugs, cookies, or other similar devices (sometimes referred to as "spyware" or "passive collection mechanisms" or "pcms").  
+* Interfere with, disrupt, or create an undue burden on the Services or the networks or services connected to the Services.  
+* Harass, annoy, intimidate, or threaten any of my employees or agents engaged in providing any portion of the Services to you.  
+* Attempt to bypass any measures of the Services designed to prevent or restrict access to the Services, or any portion of the Services.  
+* Copy or adapt the Services' software, including but not limited to Flash, PHP, HTML, JavaScript, or other code.  
+* Except as permitted by applicable law, decipher, decompile, disassemble, or reverse engineer any of the software comprising or in any way making up a part of the Services.  
+* Except as may be the result of standard search engine or Internet browser usage, use, launch, develop, or distribute any automated system, including without limitation, any spider, robot, cheat utility, scraper, or offline reader that accesses the Services, or use or launch any unauthorized script or other software.  
+* Use a buying agent or purchasing agent to make purchases on the Services.  
+* Make any unauthorized use of the Services, including collecting usernames and/or email addresses of users by electronic or other means for the purpose of sending unsolicited email, or creating user accounts by automated means or under false pretenses.  
+* Use the Services as part of any effort to compete with me or otherwise use the Services and/or the Content for any revenue-generating endeavor or commercial enterprise.  
+* Use the Services or API for commercial purposes without explicit written permission from the owner.  
+* Use the Services or API to resell, sublicense, or provide access to third parties.  
+* Use the API to make excessive, automated, or abusive requests (including scraping, DDoS, or bot usage).  
+* Circumvent, disable, or interfere with any rate limits or security features.  
+* Use the API for any illegal, harmful, or unauthorized purposes.  
+* Reverse engineer or attempt to discover the source code or underlying structure of the Services or API endpoints.
+
+## **7\. USER GENERATED CONTRIBUTIONS**
+
+The Services may invite you to chat, contribute to, or participate in blogs, message boards, online forums, and other functionality, and may provide you with the opportunity to create, submit, post, display, transmit, perform, publish, distribute, or broadcast content and materials to me or on the Services, including but not limited to text, writings, video, audio, photographs, graphics, comments, suggestions, or personal information or other material (collectively, "Contributions"). Contributions may be viewable by other users of the Services and through third-party websites. As such, any Contributions you transmit may be treated as non-confidential and non-proprietary. When you create or make available any Contributions, you thereby represent and warrant that:
+
+* The creation, distribution, transmission, public display, or performance, and the accessing, downloading, or copying of your Contributions do not and will not infringe the proprietary rights, including but not limited to the copyright, patent, trademark, trade secret, or moral rights of any third party.  
+* You are the creator and owner of or have the necessary licenses, rights, consents, releases, and permissions to use and to authorize us, the Services, and other users of the Services to use your Contributions in any manner contemplated by the Services and these Legal Terms.  
+* You have the written consent, release, and/or permission of each and every identifiable individual person in your Contributions to use the name or likeness of each and every such identifiable individual person to enable inclusion and use of your Contributions in any manner contemplated by the Services and these Legal Terms.  
+* Your Contributions are not false, inaccurate, or misleading.   
+* Your Contributions are not unsolicited or unauthorized advertising, promotional materials, pyramid schemes, chain letters, spam, mass mailings, or other forms of solicitation.  
+* Your Contributions are not obscene, lewd, lascivious, filthy, violent, harassing, libelous, slanderous, or otherwise objectionable (as determined by us).  
+* Your Contributions do not ridicule, mock, disparage, intimidate, or abuse anyone.  
+* Your Contributions are not used to harass or threaten (in the legal sense of those terms) any other person and to promote violence against a specific person or class of people.  
+* Your Contributions do not violate any applicable law, regulation, or rule.   
+* Your Contributions do not violate the privacy or publicity rights of any third party.  
+* Your Contributions do not violate any applicable law concerning child pornography, or otherwise intended to protect the health or well-being of minors.  
+* Your Contributions do not include any offensive comments that are connected to race, national origin, gender, sexual preference, or physical handicap.  
+* Your Contributions do not otherwise violate, or link to material that violates, any provision of these Legal Terms, or any applicable law or regulation.
+
+Any use of the Services in violation of the foregoing violates these Legal Terms and may result in, among other things, termination or suspension of your rights to use the Services.
+
+## **8\. CONTRIBUTION LICENSE**
+
+By posting your Contributions to any part of the Services, you automatically grant, and you represent and warrant that you have the right to grant, to me an unrestricted, unlimited, irrevocable, perpetual, non-exclusive, transferable, royalty-free, fully-paid, worldwide right, and license to host, use, copy, reproduce, disclose, sell, resell, publish, broadcast, retitle, archive, store, cache, publicly perform, publicly display, reformat, translate, transmit, excerpt (in whole or in part), and distribute such Contributions (including, without limitation, your image and voice) for any purpose, commercial, advertising, or otherwise, and to prepare derivative works of, or incorporate into other works, such Contributions, and grant and authorize sublicenses of the foregoing. The use and distribution may occur in any media formats and through any media channels.
+
+This license will apply to any form, media, or technology now known or hereafter developed, and includes my use of your name, company name, and franchise name, as applicable, and any of the trademarks, service marks, trade names, logos, and personal and commercial images you provide. You waive all moral rights in your Contributions, and you warrant that moral rights have not otherwise been asserted in your Contributions.
+
+I do not assert any ownership over your Contributions. You retain full ownership of all of your Contributions and any intellectual property rights or other proprietary rights associated with your Contributions. I am not liable for any statements or representations in your Contributions provided by you in any area on the Services. You are solely responsible for your Contributions to the Services and you expressly agree to exonerate me from any and all responsibility and to refrain from any legal action against me regarding your Contributions.
+
+I have the right, in my sole and absolute discretion, (1) to edit, redact, or otherwise change any Contributions; (2) to re-categorize any Contributions to place them in more appropriate locations on the Services; and (3) to pre-screen or delete any Contributions at any time and for any reason, without notice. I have no obligation to monitor your Contributions.
+
+## **9\. THIRD-PARTY WEBSITES AND CONTENT**
+
+The Services may contain (or you may be sent via the Site) links to other websites ("Third-Party Websites") as well as articles, photographs, text, graphics, pictures, designs, music, sound, video, information, applications, software, and other content or items belonging to or originating from third parties ("Third-Party Content"). Such Third-Party Websites and Third-Party Content are not investigated, monitored, or checked for accuracy, appropriateness, or completeness by us, and I am not responsible for any Third-Party Websites accessed through the Services or any Third-Party Content posted on, available through, or installed from the Services, including the content, accuracy, offensiveness, opinions, reliability, privacy practices, or other policies of or contained in the Third-Party Websites or the Third-Party Content. Inclusion of, linking to, or permitting the use or installation of any Third-Party Websites or any Third-Party Content does not imply approval or endorsement thereof by us. If you decide to leave the Services and access the Third-Party Websites or to use or install any Third-Party Content, you do so at your own risk, and you should be aware these Legal Terms no longer govern. You should review the applicable terms and policies, including privacy and data gathering practices, of any website to which you navigate from the Services or relating to any applications you use or install from the Services. Any purchases you make through Third-Party Websites will be through other websites and from other companies, and I take no responsibility whatsoever in relation to such purchases which are exclusively between you and the applicable third party. You agree and acknowledge that I do not endorse the products or services offered on Third-Party Websites and you shall hold me blameless from any harm caused by your purchase of such products or services. Additionally, you shall hold me blameless from any losses sustained by you or harm caused to you relating to or resulting in any way from any Third-Party Content or any contact with Third-Party Websites.
+
+## **10\. SERVICES MANAGEMENT**
+
+I reserve the right, but not the obligation, to: (1) monitor the Services for violations of these Legal Terms; (2) take appropriate legal action against anyone who, in my sole discretion, violates the law or these Legal Terms, including without limitation, reporting such user to law enforcement authorities; (3) in my sole discretion and without limitation, refuse, restrict access to, limit the availability of, or disable (to the extent technologically feasible) any of your Contributions or any portion thereof; (4) in my sole discretion and without limitation, notice, or liability, to remove from the Services or otherwise disable all files and content that are excessive in size or are in any way burdensome to my systems; and (5) otherwise manage the Services in a manner designed to protect my rights and property and to facilitate the proper functioning of the Services.
+
+## **11\. PRIVACY POLICY**
+
+I care about data privacy and security. By using the Services, you agree to be bound by my Privacy Policy posted on the Services, which is incorporated into these Legal Terms. Please be advised the Services are hosted in Denmark. If you access the Services from any other region of the world with laws or other requirements governing personal data collection, use, or disclosure that differ from applicable laws in Denmark, then through your continued use of the Services, you are transferring your data to Denmark, and you expressly consent to have your data transferred to and processed in Denmark.
+
+## **12\. TERM AND TERMINATION**
+
+These Legal Terms shall remain in full force and effect while you use the Services. WITHOUT LIMITING ANY OTHER PROVISION OF THESE LEGAL TERMS, I RESERVE THE RIGHT TO, IN OUR SOLE DISCRETION AND WITHOUT NOTICE OR LIABILITY, DENY ACCESS TO AND USE OF THE SERVICES (INCLUDING BLOCKING CERTAIN IP ADDRESSES), TO ANY PERSON FOR ANY REASON OR FOR NO REASON, INCLUDING WITHOUT LIMITATION FOR BREACH OF ANY REPRESENTATION, WARRANTY, OR COVENANT CONTAINED IN THESE LEGAL TERMS OR OF ANY APPLICABLE LAW OR REGULATION. I MAY TERMINATE YOUR USE OR PARTICIPATION IN THE SERVICES OR DELETE YOUR ACCOUNT AND ANY CONTENT OR INFORMATION THAT YOU POSTED AT ANY TIME, WITHOUT WARNING, IN OUR SOLE DISCRETION.
+
+If I terminate or suspend your account for any reason, you are prohibited from registering and creating a new account under your name, a fake or borrowed name, or the name of any third party, even if you may be acting on behalf of the third party. In addition to terminating or suspending your account, I reserve the right to take appropriate legal action, including without limitation pursuing civil, criminal, and injunctive redress.
+
+## **13\. MODIFICATIONS AND INTERRUPTIONS**
+
+I reserve the right to change, modify, or remove the contents of the Services at any time or for any reason at my sole discretion without notice. However, I have no obligation to update any information on my Services. I will not be liable to you or any third party for any modification, price change, suspension, or discontinuance of the Services.
+
+I cannot guarantee the Services will be available at all times. I may experience hardware, software, or other problems or need to perform maintenance related to the Services, resulting in interruptions, delays, or errors. I reserve the right to change, revise, update, suspend, discontinue, or otherwise modify the Services at any time or for any reason without notice to you. You agree that I have no liability whatsoever for any loss, damage, or inconvenience caused by your inability to access or use the Services during any downtime or discontinuance of the Services. Nothing in these Legal Terms will be construed to obligate me to maintain and support the Services or to supply any corrections, updates, or releases in connection therewith.
+
+## **14\. GOVERNING LAW**
+
+These Legal Terms are governed by and interpreted following the laws of Denmark, and the use of the United Nations Convention of Contracts for the International Sales of Goods is expressly excluded. If your habitual residence is in the EU, and you are a consumer, you additionally possess the protection provided to you by obligatory provisions of the law in your country to residence. Lucas Hjort Rahr Hartung and yourself both agree to submit to the non-exclusive jurisdiction of the courts of Syddanmark, which means that you may make a claim to defend your consumer protection rights in regards to these Legal Terms in Denmark, or in the EU country in which you reside.
+
+## **15\. DISPUTE RESOLUTION**
+
+### **Informal Negotiations**
+
+To expedite resolution and control the cost of any dispute, controversy, or claim related to these Legal Terms (each a "Dispute" and collectively, the "Disputes") brought by either you or me (individually, a "Party" and collectively, the "Parties"), the Parties agree to first attempt to negotiate any Dispute (except those Disputes expressly provided below) informally for at least ninety (90) days before initiating arbitration. Such informal negotiations commence upon written notice from one Party to the other Party.
+
+### **Binding Arbitration**
+
+Any dispute arising from the relationships between the Parties to these Legal Terms shall be determined by one arbitrator who will be chosen in accordance with the Arbitration and Internal Rules of the European Court of Arbitration being part of the European Centre of Arbitration having its seat in Strasbourg, and which are in force at the time the application for arbitration is filed, and of which adoption of this clause constitutes acceptance. The seat of arbitration shall be Aabenraa, Denmark. The language of the proceedings shall be English or Danish. Applicable rules of substantive law shall be the law of Denmark.
+
+### **Restrictions**
+
+The Parties agree that any arbitration shall be limited to the Dispute between the Parties individually. To the full extent permitted by law, (a) no arbitration shall be joined with any other proceeding; (b) there is no right or authority for any Dispute to be arbitrated on a class-action basis or to utilize class action procedures; and (c) there is no right or authority for any Dispute to be brought in a purported representative capacity on behalf of the general public or any other persons.
+
+### **Exceptions to Informal Negotiations and Arbitration**
+
+The Parties agree that the following Disputes are not subject to the above provisions concerning informal negotiations binding arbitration: (a) any Disputes seeking to enforce or protect, or concerning the validity of, any of the intellectual property rights of a Party; (b) any Dispute related to, or arising from, allegations of theft, piracy, invasion of privacy, or unauthorized use; and (c) any claim for injunctive relief. If this provision is found to be illegal or unenforceable, then neither Party will elect to arbitrate any Dispute falling within that portion of this provision found to be illegal or unenforceable and such Dispute shall be decided by a court of competent jurisdiction within the courts listed for jurisdiction above, and the Parties agree to submit to the personal jurisdiction of that court.
+
+## **16\. CORRECTIONS**
+
+There may be information on the Services that contains typographical errors, inaccuracies, or omissions, including descriptions, pricing, availability, and variome other information. I reserve the right to correct any errors, inaccuracies, or omissions and to change or update the information on the Services at any time, without prior notice.
+
+## **17\. DISCLAIMER**
+
+THE SERVICES ARE PROVIDED ON AN AS-IS AND AS-AVAILABLE BASIS. YOU AGREE THAT YOUR USE OF THE SERVICES WILL BE AT YOUR SOLE RISK. TO THE FULLEST EXTENT PERMITTED BY LAW, I DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, IN CONNECTION WITH THE SERVICES AND YOUR USE THEREOF, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. I MAKE NO WARRANTIES OR REPRESENTATIONS ABOUT THE ACCURACY OR COMPLETENESS OF THE SERVICES' CONTENT OR THE CONTENT OF ANY WEBSITES OR MOBILE APPLICATIONS LINKED TO THE SERVICES AND I WILL ASSUME NO LIABILITY OR RESPONSIBILITY FOR ANY (1) ERRORS, MISTAKES, OR INACCURACIES OF CONTENT AND MATERIALS, (2) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO AND USE OF THE SERVICES, (3) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY AND ALL PERSONAL INFORMATION AND/OR FINANCIAL INFORMATION STORED THEREIN, (4) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE SERVICES, (5) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE WHICH MAY BE TRANSMITTED TO OR THROUGH THE SERVICES BY ANY THIRD PARTY, AND/OR (6) ANY ERRORS OR OMISSIONS IN ANY CONTENT AND MATERIALS OR FOR ANY LOSS OR DAMAGE OF ANY KIND INCURRED AS A RESULT OF THE USE OF ANY CONTENT POSTED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE VIA THE SERVICES. I DO NOT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY PRODUCT OR SERVICE ADVERTISED OR OFFERED BY A THIRD PARTY THROUGH THE SERVICES, ANY HYPERLINKED WEBSITE, OR ANY WEBSITE OR MOBILE APPLICATION FEATURED IN ANY BANNER OR OTHER ADVERTISING, AND I WILL NOT BE A PARTY TO OR IN ANY WAY BE RESPONSIBLE FOR MONITORING ANY TRANSACTION BETWEEN YOU AND ANY THIRD-PARTY PROVIDERS OF PRODUCTS OR SERVICES. AS WITH THE PURCHASE OF A PRODUCT OR SERVICE THROUGH ANY MEDIUM OR IN ANY ENVIRONMENT, YOU SHOULD USE YOUR BEST JUDGMENT AND EXERCISE CAUTION WHERE APPROPRIATE.
+
+## **18\. LIMITATIONS OF LIABILITY**
+
+IN NO EVENT WILL I OR OUR DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT, INDIRECT, CONSEQUENTIAL, EXEMPLARY, INCIDENTAL, SPECIAL, OR PUNITIVE DAMAGES, INCLUDING LOST PROFIT, LOST REVENUE, LOSS OF DATA, OR OTHER DAMAGES ARISING FROM YOUR USE OF THE SERVICES, EVEN IF I HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO YOU FOR ANY CAUSE WHATSOEVER AND REGARDLESS OF THE FORM OF THE ACTION, WILL AT ALL TIMES BE LIMITED TO THE AMOUNT PAID, IF ANY, BY YOU TO US. CERTAIN US STATE LAWS AND INTERNATIONAL LAWS DO NOT ALLOW LIMITATIONS ON IMPLIED WARRANTIES OR THE EXCLUSION OR LIMITATION OF CERTAIN DAMAGES. IF THESE LAWS APPLY TO YOU, SOME OR ALL OF THE ABOVE DISCLAIMERS OR LIMITATIONS MAY NOT APPLY TO YOU, AND YOU MAY HAVE ADDITIONAL RIGHTS.
+
+## **19\. INDEMNIFICATION**
+
+You agree to defend, indemnify, and hold me harmless, including my subsidiaries, affiliates, and all of my respective officers, agents, partners, and employees, from and against any loss, damage, liability, claim, or demand, including reasonable attorneys’ fees and expenses, made by any third party due to or arising out of: (1) your Contributions; (2) use of the Services; (3) breach of these Legal Terms; (4) any breach of your representations and warranties set forth in these Legal Terms; (5) your violation of the rights of a third party, including but not limited to intellectual property rights; or (6) any overt harmful act toward any other user of the Services with whom you connected via the Services. Notwithstanding the foregoing, I reserve the right, at your expense, to assume the exclusive defense and control of any matter for which you are required to indemnify us, and you agree to cooperate, at your expense, with my defense of such claims. I will use reasonable efforts to notify you of any such claim, action, or proceeding which is subject to this indemnification upon becoming aware of it.
+
+## **20\. USER DATA**
+
+I will maintain certain data that you transmit to the Services for the purpose of managing the performance of the Services, as well as data relating to your use of the Services. Although I perform regular routine backups of data, you are solely responsible for all data that you transmit or that relates to any activity you have undertaken using the Services. You agree that I shall have no liability to you for any loss or corruption of any such data, and you hereby waive any right of action against me arising from any such loss or corruption of such data.
+
+## **21\. ELECTRONIC COMMUNICATIONS, TRANSACTIONS, AND SIGNATURES**
+
+Visiting the Services, sending me emails, and completing online forms constitute electronic communications. You consent to receive electronic communications, and you agree that all agreements, notices, disclosures, and other communications I provide to you electronically, via email and on the Services, satisfy any legal requirement that such communication be in writing. YOU HEREBY AGREE TO THE USE OF ELECTRONIC SIGNATURES, CONTRACTS, ORDERS, AND OTHER RECORDS, AND TO ELECTRONIC DELIVERY OF NOTICES, POLICIES, AND RECORDS OF TRANSACTIONS INITIATED OR COMPLETED BY US OR VIA THE SERVICES. You hereby waive any rights or requirements under any statutes, regulations, rules, ordinances, or other laws in any jurisdiction which require an original signature or delivery or retention of non-electronic records, or to payments or the granting of credits by any means other than electronic means.
+
+## **22\. CALIFORNIA USERS AND RESIDENTS**
+
+If any complaint with me is not satisfactorily resolved, you can contact the Complaint Assistance Unit of the Division of Consumer Services of the California Department of Consumer Affairs in writing at 1625 North Market Blvd., Suite N 112, Sacramento, California 95834 or by telephone at (800) 952-5210 or (916) 445-1254.
+
+## **23\. MISCELLANEOUS**
+
+These Legal Terms and any policies or operating rules posted by me on the Services or in respect to the Services constitute the entire agreement and understanding between you and us. My failure to exercise or enforce any right or provision of these Legal Terms shall not operate as a waiver of such right or provision. These Legal Terms operate to the fullest extent permissible by law. I may assign any or all of my rights and obligations to others at any time. I shall not be responsible or liable for any loss, damage, delay, or failure to act caused by any cause beyond my reasonable control. If any provision or part of a provision of these Legal Terms is determined to be unlawful, void, or unenforceable, that provision or part of the provision is deemed severable from these Legal Terms and does not affect the validity and enforceability of any remaining provisions. There is no joint venture, partnership, employment or agency relationship created between you and me as a result of these Legal Terms or use of the Services. You agree that these Legal Terms will not be construed against me by virtue of having drafted them. You hereby waive any and all defenses you may have based on the electronic form of these Legal Terms and the lack of signing by the parties hereto to execute these Legal Terms.
+
+**API USAGE AND ACCESS**  
+The publicly available API endpoints provided as part of this service are intended for personal and non-commercial use only. Use of the API for commercial purposes, including but not limited to integrating the API into paid products or services, requires explicit written permission from the owner. Abuse, excessive use, or circumvention of API rate limits is strictly prohibited. The owner reserves the right to revoke or restrict API access at any time, for any reason, without notice. For commercial licensing or access to higher usage limits, please contact lhrh.privat@gmail.com.
+
+## **25\. CONTACT US**
+
+In order to resolve a complaint regarding the Services or to receive further information regarding use of the Services, please contact me at:
+
+**Lucas Hjort Rahr Hartung**  
+**Denmark**  
+**lhrh.privat@gmail.com**  
+</script>
+      </main>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script>
+      const md = document.getElementById("tosMarkdown").textContent;
+      document.getElementById("tosContent").innerHTML = marked.parse(md);
+    </script>
+    <script src="assets/js/darkmode.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML versions of Terms of Service and Privacy Notice using a markdown converter
- link to these pages from the signup page

## Testing
- `npm test` *(fails: package.json missing)*