### PR TITLE
Fix privacy grammar and add anchor links

### DIFF
--- a/Privacy Notice Pilot Dashboard.md
+++ b/Privacy Notice Pilot Dashboard.md
@@ -8,7 +8,7 @@ This Privacy Notice for Lucas Hjort Rahr Hartung ("**I**," "**me**," or "**my**"
 * Use Pilot Dashboard. Pilot Dashboard is a free, open-source web app designed to help pilots plan, log, and analyze their flights. It is built with a focus on simplicity, usability, and data privacy.  
 * Engage with me in other related ways, including any sales, marketing, or events
 
-**Questions or concerns?** Reading this Privacy Notice will help you understand your privacy rights and choices. I are responsible for making decisions about how your personal information is processed. If you do not agree with my policies and practices, please do not use my Services. If you still have any questions or concerns, please contact me at lhrh.privat@gmail.com.
+**Questions or concerns?** Reading this Privacy Notice will help you understand your privacy rights and choices. I am responsible for making decisions about how your personal information is processed. If you do not agree with my policies and practices, please do not use my Services. If you still have any questions or concerns, please contact me at lhrh.privat@gmail.com.
 
 ## **SUMMARY OF KEY POINTS**
 
@@ -103,7 +103,7 @@ The General Data Protection Regulation (GDPR) and UK GDPR require me to explain 
 * **Legitimate Interests.** I may process your information when I believe it is reasonably necessary to achieve my legitimate business interests and those interests do not outweigh your interests and fundamental rights and freedoms. For example, I may process your personal information for some of the purposes described in order to:  
 * Analyze how my Services are used so I can improve them to engage and retain users  
 * Diagnose problems and/or prevent fraudulent activities  
-* **Legal Obligations.** I may process your information where I believe it is necessary for compliance with my legal obligations, such as to cooperate with a law enforcement body or regulatory agency, exercise or defend my legal rights, or disclose your information as evidence in litigation in which I are involved.  
+* **Legal Obligations.** I may process your information where I believe it is necessary for compliance with my legal obligations, such as to cooperate with a law enforcement body or regulatory agency, exercise or defend my legal rights, or disclose your information as evidence in litigation in which I am involved.  
 * **Vital Interests.** I may process your information where I believe it is necessary to protect your vital interests or the vital interests of a third party, such as situations involving potential threats to the safety of any person.
 
 ***If you are located in Canada, this section applies to you.***
@@ -202,11 +202,11 @@ In some regions (like the EEA, UK, Switzerland, and Canada), you have certain ri
 
 I will consider and act upon any request in accordance with applicable data protection laws.  
    
-If you are located in the EEA or UK and you believe I are unlawfully processing your personal information, you also have the right to complain to your [Member State data protection authority](https://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm) or [UK data protection authority](https://ico.org.uk/make-a-complaint/data-protection-complaints/data-protection-complaints/).
+If you are located in the EEA or UK and you believe I am unlawfully processing your personal information, you also have the right to complain to your [Member State data protection authority](https://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm) or [UK data protection authority](https://ico.org.uk/make-a-complaint/data-protection-complaints/data-protection-complaints/).
 
 If you are located in Switzerland, you may contact the [Federal Data Protection and Information Commissioner](https://www.edoeb.admin.ch/edoeb/en/home.html).
 
-**Withdrawing your consent:** If I are relying on your consent to process your personal information, which may be express and/or implied consent depending on the applicable law, you have the right to withdraw your consent at any time. You can withdraw your consent at any time by contacting me by using the contact details provided in the section "[HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](https://pilot-dashboard.e57.dk/privacy-notice.html#contact)" below.
+**Withdrawing your consent:** If I am relying on your consent to process your personal information, which may be express and/or implied consent depending on the applicable law, you have the right to withdraw your consent at any time. You can withdraw your consent at any time by contacting me by using the contact details provided in the section "[HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](https://pilot-dashboard.e57.dk/privacy-notice.html#contact)" below.
 
 However, please note that this will not affect the lawfulness of the processing before its withdrawal nor, when applicable law allows, will it affect the processing of your personal information conducted in reliance on lawful processing grounds other than consent.
 
@@ -283,7 +283,7 @@ I have not disclosed, sold, or shared any personal information to third parties 
 
 You have rights under certain US state data protection laws. However, these rights are not absolute, and in certain cases, I may decline your request as permitted by law. These rights include:
 
-* **Right to know** whether or not I are processing your personal data  
+* **Right to know** whether or not I am processing your personal data  
 * **Right to access** your personal data  
 * **Right to correct** inaccuracies in your personal data  
 * **Right to request** the deletion of your personal data  
@@ -319,7 +319,7 @@ I use browser local storage to store your preferences and login tokens. No track
 
 ***In Short:** Yes, I will update this notice as necessary to stay compliant with relevant laws.*
 
-I may update this Privacy Notice from time to time. The updated version will be indicated by an updated "Revised" date at the top of this Privacy Notice. If I make material changes to this Privacy Notice, I may notify you either by prominently posting a notice of such changes or by directly sending you a notification. I encourage you to review this Privacy Notice frequently to be informed of how I are protecting your information.
+I may update this Privacy Notice from time to time. The updated version will be indicated by an updated "Revised" date at the top of this Privacy Notice. If I make material changes to this Privacy Notice, I may notify you either by prominently posting a notice of such changes or by directly sending you a notification. I encourage you to review this Privacy Notice frequently to be informed of how I am protecting your information.
 
 ## **17\. HOW CAN YOU CONTACT US ABOUT THIS NOTICE?**
 

--- a/ToS Pilot Dashboard.md
+++ b/ToS Pilot Dashboard.md
@@ -48,12 +48,14 @@ I recommend that you print a copy of these Legal Terms for your records.
 [24\. API USAGE AND ACCESS](https://pilot-dashboard.e57.dk/terms-of-service.html#addclause)  
 [25\. CONTACT US](https://pilot-dashboard.e57.dk/terms-of-service.html#contact)
 
+<div id="services"></div>
 ## **1\. OUR SERVICES**
 
 The information provided when using the Services is not intended for distribution to or use by any person or entity in any jurisdiction or country where such distribution or use would be contrary to law or regulation or which would subject me to any registration requirement within such jurisdiction or country. Accordingly, those persons who choose to access the Services from other locations do so on their own initiative and are solely responsible for compliance with local laws, if and to the extent local laws are applicable.
 
 The Services are not tailored to comply with industry-specific regulations (Health Insurance Portability and Accountability Act (HIPAA), Federal Information Security Management Act (FISMA), etc.), so if your interactions would be subjected to such laws, you may not use the Services. You may not use the Services in a way that would violate the Gramm-Leach-Bliley Act (GLBA).
 
+<div id="ip"></div>
 ## **2\. INTELLECTUAL PROPERTY RIGHTS**
 
 ### **My intellectual property**
@@ -106,16 +108,19 @@ You are solely responsible for your Submissions and/or Contributions and you exp
 
 **I may remove or edit your Content:** Although I have no obligation to monitor any Contributions, I shall have the right to remove or edit any Contributions at any time without notice if in my reasonable opinion I consider such Contributions harmful or in breach of these Legal Terms. If I remove or edit any such Contributions, I may also suspend or disable your account and report you to the authorities.
 
+<div id="userreps"></div>
 ## **3\. USER REPRESENTATIONS**
 
 By using the Services, you represent and warrant that: (1) all registration information you submit will be true, accurate, current, and complete; (2) you will maintain the accuracy of such information and promptly update such registration information as necessary; (3) you have the legal capacity and you agree to comply with these Legal Terms; (4) you are not a minor in the jurisdiction in which you reside, or if a minor, you have received parental permission to use the Services; (5) you will not access the Services through automated or non-human means, whether through a bot, script or otherwise; (6) you will not use the Services for any illegal or unauthorized purpose; and (7) your use of the Services will not violate any applicable law or regulation.
 
 If you provide any information that is untrue, inaccurate, not current, or incomplete, I have the right to suspend or terminate your account and refuse any and all current or future use of the Services (or any portion thereof).
 
+<div id="userreg"></div>
 ## **4\. USER REGISTRATION**
 
 You may be required to register to use the Services. You agree to keep your password confidential and will be responsible for all use of your account and password. I reserve the right to remove, reclaim, or change a username you select if I determine, in my sole discretion, that such username is inappropriate, obscene, or otherwise objectionable.
 
+<div id="purchases"></div>
 ## **5\. PURCHASES AND PAYMENT**
 
 I accept the following forms of payment:
@@ -128,6 +133,7 @@ You agree to pay all charges at the prices then in effect for your purchases and
 
 I reserve the right to refuse any order placed through the Services. I may, in my sole discretion, limit or cancel quantities purchased per person, per household, or per order. These restrictions may include orders placed by or under the same customer account, the same payment method, and/or orders that use the same billing or shipping address. I reserve the right to limit or prohibit orders that, in my sole judgment, appear to be placed by dealers, resellers, or distributors.
 
+<div id="prohibited"></div>
 ## **6\. PROHIBITED ACTIVITIES**
 
 You may not access or use the Services for any purpose other than that for which I make the Services available. The Services may not be used in connection with any commercial endeavors except those that are specifically endorsed or approved by us.
@@ -163,6 +169,7 @@ As a user of the Services, you agree not to:
 * Use the API for any illegal, harmful, or unauthorized purposes.  
 * Reverse engineer or attempt to discover the source code or underlying structure of the Services or API endpoints.
 
+<div id="ugc"></div>
 ## **7\. USER GENERATED CONTRIBUTIONS**
 
 The Services may invite you to chat, contribute to, or participate in blogs, message boards, online forums, and other functionality, and may provide you with the opportunity to create, submit, post, display, transmit, perform, publish, distribute, or broadcast content and materials to me or on the Services, including but not limited to text, writings, video, audio, photographs, graphics, comments, suggestions, or personal information or other material (collectively, "Contributions"). Contributions may be viewable by other users of the Services and through third-party websites. As such, any Contributions you transmit may be treated as non-confidential and non-proprietary. When you create or make available any Contributions, you thereby represent and warrant that:
@@ -183,6 +190,7 @@ The Services may invite you to chat, contribute to, or participate in blogs, mes
 
 Any use of the Services in violation of the foregoing violates these Legal Terms and may result in, among other things, termination or suspension of your rights to use the Services.
 
+<div id="license"></div>
 ## **8\. CONTRIBUTION LICENSE**
 
 By posting your Contributions to any part of the Services, you automatically grant, and you represent and warrant that you have the right to grant, to me an unrestricted, unlimited, irrevocable, perpetual, non-exclusive, transferable, royalty-free, fully-paid, worldwide right, and license to host, use, copy, reproduce, disclose, sell, resell, publish, broadcast, retitle, archive, store, cache, publicly perform, publicly display, reformat, translate, transmit, excerpt (in whole or in part), and distribute such Contributions (including, without limitation, your image and voice) for any purpose, commercial, advertising, or otherwise, and to prepare derivative works of, or incorporate into other works, such Contributions, and grant and authorize sublicenses of the foregoing. The use and distribution may occur in any media formats and through any media channels.
@@ -193,34 +201,41 @@ I do not assert any ownership over your Contributions. You retain full ownership
 
 I have the right, in my sole and absolute discretion, (1) to edit, redact, or otherwise change any Contributions; (2) to re-categorize any Contributions to place them in more appropriate locations on the Services; and (3) to pre-screen or delete any Contributions at any time and for any reason, without notice. I have no obligation to monitor your Contributions.
 
+<div id="thirdparty"></div>
 ## **9\. THIRD-PARTY WEBSITES AND CONTENT**
 
 The Services may contain (or you may be sent via the Site) links to other websites ("Third-Party Websites") as well as articles, photographs, text, graphics, pictures, designs, music, sound, video, information, applications, software, and other content or items belonging to or originating from third parties ("Third-Party Content"). Such Third-Party Websites and Third-Party Content are not investigated, monitored, or checked for accuracy, appropriateness, or completeness by us, and I am not responsible for any Third-Party Websites accessed through the Services or any Third-Party Content posted on, available through, or installed from the Services, including the content, accuracy, offensiveness, opinions, reliability, privacy practices, or other policies of or contained in the Third-Party Websites or the Third-Party Content. Inclusion of, linking to, or permitting the use or installation of any Third-Party Websites or any Third-Party Content does not imply approval or endorsement thereof by us. If you decide to leave the Services and access the Third-Party Websites or to use or install any Third-Party Content, you do so at your own risk, and you should be aware these Legal Terms no longer govern. You should review the applicable terms and policies, including privacy and data gathering practices, of any website to which you navigate from the Services or relating to any applications you use or install from the Services. Any purchases you make through Third-Party Websites will be through other websites and from other companies, and I take no responsibility whatsoever in relation to such purchases which are exclusively between you and the applicable third party. You agree and acknowledge that I do not endorse the products or services offered on Third-Party Websites and you shall hold me blameless from any harm caused by your purchase of such products or services. Additionally, you shall hold me blameless from any losses sustained by you or harm caused to you relating to or resulting in any way from any Third-Party Content or any contact with Third-Party Websites.
 
+<div id="sitemanage"></div>
 ## **10\. SERVICES MANAGEMENT**
 
 I reserve the right, but not the obligation, to: (1) monitor the Services for violations of these Legal Terms; (2) take appropriate legal action against anyone who, in my sole discretion, violates the law or these Legal Terms, including without limitation, reporting such user to law enforcement authorities; (3) in my sole discretion and without limitation, refuse, restrict access to, limit the availability of, or disable (to the extent technologically feasible) any of your Contributions or any portion thereof; (4) in my sole discretion and without limitation, notice, or liability, to remove from the Services or otherwise disable all files and content that are excessive in size or are in any way burdensome to my systems; and (5) otherwise manage the Services in a manner designed to protect my rights and property and to facilitate the proper functioning of the Services.
 
+<div id="ppno"></div>
 ## **11\. PRIVACY POLICY**
 
 I care about data privacy and security. By using the Services, you agree to be bound by my Privacy Policy posted on the Services, which is incorporated into these Legal Terms. Please be advised the Services are hosted in Denmark. If you access the Services from any other region of the world with laws or other requirements governing personal data collection, use, or disclosure that differ from applicable laws in Denmark, then through your continued use of the Services, you are transferring your data to Denmark, and you expressly consent to have your data transferred to and processed in Denmark.
 
+<div id="terms"></div>
 ## **12\. TERM AND TERMINATION**
 
 These Legal Terms shall remain in full force and effect while you use the Services. WITHOUT LIMITING ANY OTHER PROVISION OF THESE LEGAL TERMS, I RESERVE THE RIGHT TO, IN OUR SOLE DISCRETION AND WITHOUT NOTICE OR LIABILITY, DENY ACCESS TO AND USE OF THE SERVICES (INCLUDING BLOCKING CERTAIN IP ADDRESSES), TO ANY PERSON FOR ANY REASON OR FOR NO REASON, INCLUDING WITHOUT LIMITATION FOR BREACH OF ANY REPRESENTATION, WARRANTY, OR COVENANT CONTAINED IN THESE LEGAL TERMS OR OF ANY APPLICABLE LAW OR REGULATION. I MAY TERMINATE YOUR USE OR PARTICIPATION IN THE SERVICES OR DELETE YOUR ACCOUNT AND ANY CONTENT OR INFORMATION THAT YOU POSTED AT ANY TIME, WITHOUT WARNING, IN OUR SOLE DISCRETION.
 
 If I terminate or suspend your account for any reason, you are prohibited from registering and creating a new account under your name, a fake or borrowed name, or the name of any third party, even if you may be acting on behalf of the third party. In addition to terminating or suspending your account, I reserve the right to take appropriate legal action, including without limitation pursuing civil, criminal, and injunctive redress.
 
+<div id="modifications"></div>
 ## **13\. MODIFICATIONS AND INTERRUPTIONS**
 
 I reserve the right to change, modify, or remove the contents of the Services at any time or for any reason at my sole discretion without notice. However, I have no obligation to update any information on my Services. I will not be liable to you or any third party for any modification, price change, suspension, or discontinuance of the Services.
 
 I cannot guarantee the Services will be available at all times. I may experience hardware, software, or other problems or need to perform maintenance related to the Services, resulting in interruptions, delays, or errors. I reserve the right to change, revise, update, suspend, discontinue, or otherwise modify the Services at any time or for any reason without notice to you. You agree that I have no liability whatsoever for any loss, damage, or inconvenience caused by your inability to access or use the Services during any downtime or discontinuance of the Services. Nothing in these Legal Terms will be construed to obligate me to maintain and support the Services or to supply any corrections, updates, or releases in connection therewith.
 
+<div id="law"></div>
 ## **14\. GOVERNING LAW**
 
 These Legal Terms are governed by and interpreted following the laws of Denmark, and the use of the United Nations Convention of Contracts for the International Sales of Goods is expressly excluded. If your habitual residence is in the EU, and you are a consumer, you additionally possess the protection provided to you by obligatory provisions of the law in your country to residence. Lucas Hjort Rahr Hartung and yourself both agree to submit to the non-exclusive jurisdiction of the courts of Syddanmark, which means that you may make a claim to defend your consumer protection rights in regards to these Legal Terms in Denmark, or in the EU country in which you reside.
 
+<div id="disputes"></div>
 ## **15\. DISPUTE RESOLUTION**
 
 ### **Informal Negotiations**
@@ -239,41 +254,51 @@ The Parties agree that any arbitration shall be limited to the Dispute between t
 
 The Parties agree that the following Disputes are not subject to the above provisions concerning informal negotiations binding arbitration: (a) any Disputes seeking to enforce or protect, or concerning the validity of, any of the intellectual property rights of a Party; (b) any Dispute related to, or arising from, allegations of theft, piracy, invasion of privacy, or unauthorized use; and (c) any claim for injunctive relief. If this provision is found to be illegal or unenforceable, then neither Party will elect to arbitrate any Dispute falling within that portion of this provision found to be illegal or unenforceable and such Dispute shall be decided by a court of competent jurisdiction within the courts listed for jurisdiction above, and the Parties agree to submit to the personal jurisdiction of that court.
 
+<div id="corrections"></div>
 ## **16\. CORRECTIONS**
 
 There may be information on the Services that contains typographical errors, inaccuracies, or omissions, including descriptions, pricing, availability, and variome other information. I reserve the right to correct any errors, inaccuracies, or omissions and to change or update the information on the Services at any time, without prior notice.
 
+<div id="disclaimer"></div>
 ## **17\. DISCLAIMER**
 
 THE SERVICES ARE PROVIDED ON AN AS-IS AND AS-AVAILABLE BASIS. YOU AGREE THAT YOUR USE OF THE SERVICES WILL BE AT YOUR SOLE RISK. TO THE FULLEST EXTENT PERMITTED BY LAW, I DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, IN CONNECTION WITH THE SERVICES AND YOUR USE THEREOF, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. I MAKE NO WARRANTIES OR REPRESENTATIONS ABOUT THE ACCURACY OR COMPLETENESS OF THE SERVICES' CONTENT OR THE CONTENT OF ANY WEBSITES OR MOBILE APPLICATIONS LINKED TO THE SERVICES AND I WILL ASSUME NO LIABILITY OR RESPONSIBILITY FOR ANY (1) ERRORS, MISTAKES, OR INACCURACIES OF CONTENT AND MATERIALS, (2) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO AND USE OF THE SERVICES, (3) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY AND ALL PERSONAL INFORMATION AND/OR FINANCIAL INFORMATION STORED THEREIN, (4) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE SERVICES, (5) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE WHICH MAY BE TRANSMITTED TO OR THROUGH THE SERVICES BY ANY THIRD PARTY, AND/OR (6) ANY ERRORS OR OMISSIONS IN ANY CONTENT AND MATERIALS OR FOR ANY LOSS OR DAMAGE OF ANY KIND INCURRED AS A RESULT OF THE USE OF ANY CONTENT POSTED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE VIA THE SERVICES. I DO NOT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY PRODUCT OR SERVICE ADVERTISED OR OFFERED BY A THIRD PARTY THROUGH THE SERVICES, ANY HYPERLINKED WEBSITE, OR ANY WEBSITE OR MOBILE APPLICATION FEATURED IN ANY BANNER OR OTHER ADVERTISING, AND I WILL NOT BE A PARTY TO OR IN ANY WAY BE RESPONSIBLE FOR MONITORING ANY TRANSACTION BETWEEN YOU AND ANY THIRD-PARTY PROVIDERS OF PRODUCTS OR SERVICES. AS WITH THE PURCHASE OF A PRODUCT OR SERVICE THROUGH ANY MEDIUM OR IN ANY ENVIRONMENT, YOU SHOULD USE YOUR BEST JUDGMENT AND EXERCISE CAUTION WHERE APPROPRIATE.
 
+<div id="liability"></div>
 ## **18\. LIMITATIONS OF LIABILITY**
 
 IN NO EVENT WILL I OR OUR DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT, INDIRECT, CONSEQUENTIAL, EXEMPLARY, INCIDENTAL, SPECIAL, OR PUNITIVE DAMAGES, INCLUDING LOST PROFIT, LOST REVENUE, LOSS OF DATA, OR OTHER DAMAGES ARISING FROM YOUR USE OF THE SERVICES, EVEN IF I HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO YOU FOR ANY CAUSE WHATSOEVER AND REGARDLESS OF THE FORM OF THE ACTION, WILL AT ALL TIMES BE LIMITED TO THE AMOUNT PAID, IF ANY, BY YOU TO US. CERTAIN US STATE LAWS AND INTERNATIONAL LAWS DO NOT ALLOW LIMITATIONS ON IMPLIED WARRANTIES OR THE EXCLUSION OR LIMITATION OF CERTAIN DAMAGES. IF THESE LAWS APPLY TO YOU, SOME OR ALL OF THE ABOVE DISCLAIMERS OR LIMITATIONS MAY NOT APPLY TO YOU, AND YOU MAY HAVE ADDITIONAL RIGHTS.
 
+<div id="indemnification"></div>
 ## **19\. INDEMNIFICATION**
 
 You agree to defend, indemnify, and hold me harmless, including my subsidiaries, affiliates, and all of my respective officers, agents, partners, and employees, from and against any loss, damage, liability, claim, or demand, including reasonable attorneys’ fees and expenses, made by any third party due to or arising out of: (1) your Contributions; (2) use of the Services; (3) breach of these Legal Terms; (4) any breach of your representations and warranties set forth in these Legal Terms; (5) your violation of the rights of a third party, including but not limited to intellectual property rights; or (6) any overt harmful act toward any other user of the Services with whom you connected via the Services. Notwithstanding the foregoing, I reserve the right, at your expense, to assume the exclusive defense and control of any matter for which you are required to indemnify us, and you agree to cooperate, at your expense, with my defense of such claims. I will use reasonable efforts to notify you of any such claim, action, or proceeding which is subject to this indemnification upon becoming aware of it.
 
+<div id="userdata"></div>
 ## **20\. USER DATA**
 
 I will maintain certain data that you transmit to the Services for the purpose of managing the performance of the Services, as well as data relating to your use of the Services. Although I perform regular routine backups of data, you are solely responsible for all data that you transmit or that relates to any activity you have undertaken using the Services. You agree that I shall have no liability to you for any loss or corruption of any such data, and you hereby waive any right of action against me arising from any such loss or corruption of such data.
 
+<div id="electronic"></div>
 ## **21\. ELECTRONIC COMMUNICATIONS, TRANSACTIONS, AND SIGNATURES**
 
 Visiting the Services, sending me emails, and completing online forms constitute electronic communications. You consent to receive electronic communications, and you agree that all agreements, notices, disclosures, and other communications I provide to you electronically, via email and on the Services, satisfy any legal requirement that such communication be in writing. YOU HEREBY AGREE TO THE USE OF ELECTRONIC SIGNATURES, CONTRACTS, ORDERS, AND OTHER RECORDS, AND TO ELECTRONIC DELIVERY OF NOTICES, POLICIES, AND RECORDS OF TRANSACTIONS INITIATED OR COMPLETED BY US OR VIA THE SERVICES. You hereby waive any rights or requirements under any statutes, regulations, rules, ordinances, or other laws in any jurisdiction which require an original signature or delivery or retention of non-electronic records, or to payments or the granting of credits by any means other than electronic means.
 
+<div id="california"></div>
 ## **22\. CALIFORNIA USERS AND RESIDENTS**
 
 If any complaint with me is not satisfactorily resolved, you can contact the Complaint Assistance Unit of the Division of Consumer Services of the California Department of Consumer Affairs in writing at 1625 North Market Blvd., Suite N 112, Sacramento, California 95834 or by telephone at (800) 952-5210 or (916) 445-1254.
 
+<div id="misc"></div>
 ## **23\. MISCELLANEOUS**
 
 These Legal Terms and any policies or operating rules posted by me on the Services or in respect to the Services constitute the entire agreement and understanding between you and us. My failure to exercise or enforce any right or provision of these Legal Terms shall not operate as a waiver of such right or provision. These Legal Terms operate to the fullest extent permissible by law. I may assign any or all of my rights and obligations to others at any time. I shall not be responsible or liable for any loss, damage, delay, or failure to act caused by any cause beyond my reasonable control. If any provision or part of a provision of these Legal Terms is determined to be unlawful, void, or unenforceable, that provision or part of the provision is deemed severable from these Legal Terms and does not affect the validity and enforceability of any remaining provisions. There is no joint venture, partnership, employment or agency relationship created between you and me as a result of these Legal Terms or use of the Services. You agree that these Legal Terms will not be construed against me by virtue of having drafted them. You hereby waive any and all defenses you may have based on the electronic form of these Legal Terms and the lack of signing by the parties hereto to execute these Legal Terms.
 
-**API USAGE AND ACCESS**  
+<div id="addclause"></div>
+## **24. API USAGE AND ACCESS**  
 The publicly available API endpoints provided as part of this service are intended for personal and non-commercial use only. Use of the API for commercial purposes, including but not limited to integrating the API into paid products or services, requires explicit written permission from the owner. Abuse, excessive use, or circumvention of API rate limits is strictly prohibited. The owner reserves the right to revoke or restrict API access at any time, for any reason, without notice. For commercial licensing or access to higher usage limits, please contact lhrh.privat@gmail.com.
 
+<div id="contact"></div>
 ## **25\. CONTACT US**
 
 In order to resolve a complaint regarding the Services or to receive further information regarding use of the Services, please contact me at:

--- a/about.html
+++ b/about.html
@@ -61,6 +61,7 @@
             <em>your data:</em>
             always exportable, always under your control, never held hostage
             or sold.
+            <br />For full details, see our <a href="privacy-notice.html">Privacy Notice</a> and <a href="terms-of-service.html">Terms of Service</a>.
           </p>
         </div>
 

--- a/privacy-notice.html
+++ b/privacy-notice.html
@@ -30,7 +30,7 @@ This Privacy Notice for Lucas Hjort Rahr Hartung ("**I**," "**me**," or "**my**"
 * Use Pilot Dashboard. Pilot Dashboard is a free, open-source web app designed to help pilots plan, log, and analyze their flights. It is built with a focus on simplicity, usability, and data privacy.  
 * Engage with me in other related ways, including any sales, marketing, or events
 
-**Questions or concerns?** Reading this Privacy Notice will help you understand your privacy rights and choices. I are responsible for making decisions about how your personal information is processed. If you do not agree with my policies and practices, please do not use my Services. If you still have any questions or concerns, please contact me at lhrh.privat@gmail.com.
+**Questions or concerns?** Reading this Privacy Notice will help you understand your privacy rights and choices. I am responsible for making decisions about how your personal information is processed. If you do not agree with my policies and practices, please do not use my Services. If you still have any questions or concerns, please contact me at lhrh.privat@gmail.com.
 
 ## **SUMMARY OF KEY POINTS**
 
@@ -125,7 +125,7 @@ The General Data Protection Regulation (GDPR) and UK GDPR require me to explain 
 * **Legitimate Interests.** I may process your information when I believe it is reasonably necessary to achieve my legitimate business interests and those interests do not outweigh your interests and fundamental rights and freedoms. For example, I may process your personal information for some of the purposes described in order to:  
 * Analyze how my Services are used so I can improve them to engage and retain users  
 * Diagnose problems and/or prevent fraudulent activities  
-* **Legal Obligations.** I may process your information where I believe it is necessary for compliance with my legal obligations, such as to cooperate with a law enforcement body or regulatory agency, exercise or defend my legal rights, or disclose your information as evidence in litigation in which I are involved.  
+* **Legal Obligations.** I may process your information where I believe it is necessary for compliance with my legal obligations, such as to cooperate with a law enforcement body or regulatory agency, exercise or defend my legal rights, or disclose your information as evidence in litigation in which I am involved.  
 * **Vital Interests.** I may process your information where I believe it is necessary to protect your vital interests or the vital interests of a third party, such as situations involving potential threats to the safety of any person.
 
 ***If you are located in Canada, this section applies to you.***
@@ -224,11 +224,11 @@ In some regions (like the EEA, UK, Switzerland, and Canada), you have certain ri
 
 I will consider and act upon any request in accordance with applicable data protection laws.  
    
-If you are located in the EEA or UK and you believe I are unlawfully processing your personal information, you also have the right to complain to your [Member State data protection authority](https://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm) or [UK data protection authority](https://ico.org.uk/make-a-complaint/data-protection-complaints/data-protection-complaints/).
+If you are located in the EEA or UK and you believe I am unlawfully processing your personal information, you also have the right to complain to your [Member State data protection authority](https://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm) or [UK data protection authority](https://ico.org.uk/make-a-complaint/data-protection-complaints/data-protection-complaints/).
 
 If you are located in Switzerland, you may contact the [Federal Data Protection and Information Commissioner](https://www.edoeb.admin.ch/edoeb/en/home.html).
 
-**Withdrawing your consent:** If I are relying on your consent to process your personal information, which may be express and/or implied consent depending on the applicable law, you have the right to withdraw your consent at any time. You can withdraw your consent at any time by contacting me by using the contact details provided in the section "[HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](https://pilot-dashboard.e57.dk/privacy-notice.html#contact)" below.
+**Withdrawing your consent:** If I am relying on your consent to process your personal information, which may be express and/or implied consent depending on the applicable law, you have the right to withdraw your consent at any time. You can withdraw your consent at any time by contacting me by using the contact details provided in the section "[HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](https://pilot-dashboard.e57.dk/privacy-notice.html#contact)" below.
 
 However, please note that this will not affect the lawfulness of the processing before its withdrawal nor, when applicable law allows, will it affect the processing of your personal information conducted in reliance on lawful processing grounds other than consent.
 
@@ -305,7 +305,7 @@ I have not disclosed, sold, or shared any personal information to third parties 
 
 You have rights under certain US state data protection laws. However, these rights are not absolute, and in certain cases, I may decline your request as permitted by law. These rights include:
 
-* **Right to know** whether or not I are processing your personal data  
+* **Right to know** whether or not I am processing your personal data  
 * **Right to access** your personal data  
 * **Right to correct** inaccuracies in your personal data  
 * **Right to request** the deletion of your personal data  
@@ -341,7 +341,7 @@ I use browser local storage to store your preferences and login tokens. No track
 
 ***In Short:** Yes, I will update this notice as necessary to stay compliant with relevant laws.*
 
-I may update this Privacy Notice from time to time. The updated version will be indicated by an updated "Revised" date at the top of this Privacy Notice. If I make material changes to this Privacy Notice, I may notify you either by prominently posting a notice of such changes or by directly sending you a notification. I encourage you to review this Privacy Notice frequently to be informed of how I are protecting your information.
+I may update this Privacy Notice from time to time. The updated version will be indicated by an updated "Revised" date at the top of this Privacy Notice. If I make material changes to this Privacy Notice, I may notify you either by prominently posting a notice of such changes or by directly sending you a notification. I encourage you to review this Privacy Notice frequently to be informed of how I am protecting your information.
 
 ## **17\. HOW CAN YOU CONTACT ME ABOUT THIS NOTICE?**
 

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -70,12 +70,14 @@ I recommend that you print a copy of these Legal Terms for your records.
 [24\. API USAGE AND ACCESS](https://pilot-dashboard.e57.dk/terms-of-service.html#addclause)  
 [25\. CONTACT US](https://pilot-dashboard.e57.dk/terms-of-service.html#contact)
 
+<div id="services"></div>
 ## **1\. OUR SERVICES**
 
 The information provided when using the Services is not intended for distribution to or use by any person or entity in any jurisdiction or country where such distribution or use would be contrary to law or regulation or which would subject me to any registration requirement within such jurisdiction or country. Accordingly, those persons who choose to access the Services from other locations do so on their own initiative and are solely responsible for compliance with local laws, if and to the extent local laws are applicable.
 
 The Services are not tailored to comply with industry-specific regulations (Health Insurance Portability and Accountability Act (HIPAA), Federal Information Security Management Act (FISMA), etc.), so if your interactions would be subjected to such laws, you may not use the Services. You may not use the Services in a way that would violate the Gramm-Leach-Bliley Act (GLBA).
 
+<div id="ip"></div>
 ## **2\. INTELLECTUAL PROPERTY RIGHTS**
 
 ### **My intellectual property**
@@ -128,16 +130,19 @@ You are solely responsible for your Submissions and/or Contributions and you exp
 
 **I may remove or edit your Content:** Although I have no obligation to monitor any Contributions, I shall have the right to remove or edit any Contributions at any time without notice if in my reasonable opinion I consider such Contributions harmful or in breach of these Legal Terms. If I remove or edit any such Contributions, I may also suspend or disable your account and report you to the authorities.
 
+<div id="userreps"></div>
 ## **3\. USER REPRESENTATIONS**
 
 By using the Services, you represent and warrant that: (1) all registration information you submit will be true, accurate, current, and complete; (2) you will maintain the accuracy of such information and promptly update such registration information as necessary; (3) you have the legal capacity and you agree to comply with these Legal Terms; (4) you are not a minor in the jurisdiction in which you reside, or if a minor, you have received parental permission to use the Services; (5) you will not access the Services through automated or non-human means, whether through a bot, script or otherwise; (6) you will not use the Services for any illegal or unauthorized purpose; and (7) your use of the Services will not violate any applicable law or regulation.
 
 If you provide any information that is untrue, inaccurate, not current, or incomplete, I have the right to suspend or terminate your account and refuse any and all current or future use of the Services (or any portion thereof).
 
+<div id="userreg"></div>
 ## **4\. USER REGISTRATION**
 
 You may be required to register to use the Services. You agree to keep your password confidential and will be responsible for all use of your account and password. I reserve the right to remove, reclaim, or change a username you select if I determine, in my sole discretion, that such username is inappropriate, obscene, or otherwise objectionable.
 
+<div id="purchases"></div>
 ## **5\. PURCHASES AND PAYMENT**
 
 I accept the following forms of payment:
@@ -150,6 +155,7 @@ You agree to pay all charges at the prices then in effect for your purchases and
 
 I reserve the right to refuse any order placed through the Services. I may, in my sole discretion, limit or cancel quantities purchased per person, per household, or per order. These restrictions may include orders placed by or under the same customer account, the same payment method, and/or orders that use the same billing or shipping address. I reserve the right to limit or prohibit orders that, in my sole judgment, appear to be placed by dealers, resellers, or distributors.
 
+<div id="prohibited"></div>
 ## **6\. PROHIBITED ACTIVITIES**
 
 You may not access or use the Services for any purpose other than that for which I make the Services available. The Services may not be used in connection with any commercial endeavors except those that are specifically endorsed or approved by us.
@@ -185,6 +191,7 @@ As a user of the Services, you agree not to:
 * Use the API for any illegal, harmful, or unauthorized purposes.  
 * Reverse engineer or attempt to discover the source code or underlying structure of the Services or API endpoints.
 
+<div id="ugc"></div>
 ## **7\. USER GENERATED CONTRIBUTIONS**
 
 The Services may invite you to chat, contribute to, or participate in blogs, message boards, online forums, and other functionality, and may provide you with the opportunity to create, submit, post, display, transmit, perform, publish, distribute, or broadcast content and materials to me or on the Services, including but not limited to text, writings, video, audio, photographs, graphics, comments, suggestions, or personal information or other material (collectively, "Contributions"). Contributions may be viewable by other users of the Services and through third-party websites. As such, any Contributions you transmit may be treated as non-confidential and non-proprietary. When you create or make available any Contributions, you thereby represent and warrant that:
@@ -205,6 +212,7 @@ The Services may invite you to chat, contribute to, or participate in blogs, mes
 
 Any use of the Services in violation of the foregoing violates these Legal Terms and may result in, among other things, termination or suspension of your rights to use the Services.
 
+<div id="license"></div>
 ## **8\. CONTRIBUTION LICENSE**
 
 By posting your Contributions to any part of the Services, you automatically grant, and you represent and warrant that you have the right to grant, to me an unrestricted, unlimited, irrevocable, perpetual, non-exclusive, transferable, royalty-free, fully-paid, worldwide right, and license to host, use, copy, reproduce, disclose, sell, resell, publish, broadcast, retitle, archive, store, cache, publicly perform, publicly display, reformat, translate, transmit, excerpt (in whole or in part), and distribute such Contributions (including, without limitation, your image and voice) for any purpose, commercial, advertising, or otherwise, and to prepare derivative works of, or incorporate into other works, such Contributions, and grant and authorize sublicenses of the foregoing. The use and distribution may occur in any media formats and through any media channels.
@@ -215,34 +223,41 @@ I do not assert any ownership over your Contributions. You retain full ownership
 
 I have the right, in my sole and absolute discretion, (1) to edit, redact, or otherwise change any Contributions; (2) to re-categorize any Contributions to place them in more appropriate locations on the Services; and (3) to pre-screen or delete any Contributions at any time and for any reason, without notice. I have no obligation to monitor your Contributions.
 
+<div id="thirdparty"></div>
 ## **9\. THIRD-PARTY WEBSITES AND CONTENT**
 
 The Services may contain (or you may be sent via the Site) links to other websites ("Third-Party Websites") as well as articles, photographs, text, graphics, pictures, designs, music, sound, video, information, applications, software, and other content or items belonging to or originating from third parties ("Third-Party Content"). Such Third-Party Websites and Third-Party Content are not investigated, monitored, or checked for accuracy, appropriateness, or completeness by us, and I am not responsible for any Third-Party Websites accessed through the Services or any Third-Party Content posted on, available through, or installed from the Services, including the content, accuracy, offensiveness, opinions, reliability, privacy practices, or other policies of or contained in the Third-Party Websites or the Third-Party Content. Inclusion of, linking to, or permitting the use or installation of any Third-Party Websites or any Third-Party Content does not imply approval or endorsement thereof by us. If you decide to leave the Services and access the Third-Party Websites or to use or install any Third-Party Content, you do so at your own risk, and you should be aware these Legal Terms no longer govern. You should review the applicable terms and policies, including privacy and data gathering practices, of any website to which you navigate from the Services or relating to any applications you use or install from the Services. Any purchases you make through Third-Party Websites will be through other websites and from other companies, and I take no responsibility whatsoever in relation to such purchases which are exclusively between you and the applicable third party. You agree and acknowledge that I do not endorse the products or services offered on Third-Party Websites and you shall hold me blameless from any harm caused by your purchase of such products or services. Additionally, you shall hold me blameless from any losses sustained by you or harm caused to you relating to or resulting in any way from any Third-Party Content or any contact with Third-Party Websites.
 
+<div id="sitemanage"></div>
 ## **10\. SERVICES MANAGEMENT**
 
 I reserve the right, but not the obligation, to: (1) monitor the Services for violations of these Legal Terms; (2) take appropriate legal action against anyone who, in my sole discretion, violates the law or these Legal Terms, including without limitation, reporting such user to law enforcement authorities; (3) in my sole discretion and without limitation, refuse, restrict access to, limit the availability of, or disable (to the extent technologically feasible) any of your Contributions or any portion thereof; (4) in my sole discretion and without limitation, notice, or liability, to remove from the Services or otherwise disable all files and content that are excessive in size or are in any way burdensome to my systems; and (5) otherwise manage the Services in a manner designed to protect my rights and property and to facilitate the proper functioning of the Services.
 
+<div id="ppno"></div>
 ## **11\. PRIVACY POLICY**
 
 I care about data privacy and security. By using the Services, you agree to be bound by my Privacy Policy posted on the Services, which is incorporated into these Legal Terms. Please be advised the Services are hosted in Denmark. If you access the Services from any other region of the world with laws or other requirements governing personal data collection, use, or disclosure that differ from applicable laws in Denmark, then through your continued use of the Services, you are transferring your data to Denmark, and you expressly consent to have your data transferred to and processed in Denmark.
 
+<div id="terms"></div>
 ## **12\. TERM AND TERMINATION**
 
 These Legal Terms shall remain in full force and effect while you use the Services. WITHOUT LIMITING ANY OTHER PROVISION OF THESE LEGAL TERMS, I RESERVE THE RIGHT TO, IN OUR SOLE DISCRETION AND WITHOUT NOTICE OR LIABILITY, DENY ACCESS TO AND USE OF THE SERVICES (INCLUDING BLOCKING CERTAIN IP ADDRESSES), TO ANY PERSON FOR ANY REASON OR FOR NO REASON, INCLUDING WITHOUT LIMITATION FOR BREACH OF ANY REPRESENTATION, WARRANTY, OR COVENANT CONTAINED IN THESE LEGAL TERMS OR OF ANY APPLICABLE LAW OR REGULATION. I MAY TERMINATE YOUR USE OR PARTICIPATION IN THE SERVICES OR DELETE YOUR ACCOUNT AND ANY CONTENT OR INFORMATION THAT YOU POSTED AT ANY TIME, WITHOUT WARNING, IN OUR SOLE DISCRETION.
 
 If I terminate or suspend your account for any reason, you are prohibited from registering and creating a new account under your name, a fake or borrowed name, or the name of any third party, even if you may be acting on behalf of the third party. In addition to terminating or suspending your account, I reserve the right to take appropriate legal action, including without limitation pursuing civil, criminal, and injunctive redress.
 
+<div id="modifications"></div>
 ## **13\. MODIFICATIONS AND INTERRUPTIONS**
 
 I reserve the right to change, modify, or remove the contents of the Services at any time or for any reason at my sole discretion without notice. However, I have no obligation to update any information on my Services. I will not be liable to you or any third party for any modification, price change, suspension, or discontinuance of the Services.
 
 I cannot guarantee the Services will be available at all times. I may experience hardware, software, or other problems or need to perform maintenance related to the Services, resulting in interruptions, delays, or errors. I reserve the right to change, revise, update, suspend, discontinue, or otherwise modify the Services at any time or for any reason without notice to you. You agree that I have no liability whatsoever for any loss, damage, or inconvenience caused by your inability to access or use the Services during any downtime or discontinuance of the Services. Nothing in these Legal Terms will be construed to obligate me to maintain and support the Services or to supply any corrections, updates, or releases in connection therewith.
 
+<div id="law"></div>
 ## **14\. GOVERNING LAW**
 
 These Legal Terms are governed by and interpreted following the laws of Denmark, and the use of the United Nations Convention of Contracts for the International Sales of Goods is expressly excluded. If your habitual residence is in the EU, and you are a consumer, you additionally possess the protection provided to you by obligatory provisions of the law in your country to residence. Lucas Hjort Rahr Hartung and yourself both agree to submit to the non-exclusive jurisdiction of the courts of Syddanmark, which means that you may make a claim to defend your consumer protection rights in regards to these Legal Terms in Denmark, or in the EU country in which you reside.
 
+<div id="disputes"></div>
 ## **15\. DISPUTE RESOLUTION**
 
 ### **Informal Negotiations**
@@ -261,41 +276,51 @@ The Parties agree that any arbitration shall be limited to the Dispute between t
 
 The Parties agree that the following Disputes are not subject to the above provisions concerning informal negotiations binding arbitration: (a) any Disputes seeking to enforce or protect, or concerning the validity of, any of the intellectual property rights of a Party; (b) any Dispute related to, or arising from, allegations of theft, piracy, invasion of privacy, or unauthorized use; and (c) any claim for injunctive relief. If this provision is found to be illegal or unenforceable, then neither Party will elect to arbitrate any Dispute falling within that portion of this provision found to be illegal or unenforceable and such Dispute shall be decided by a court of competent jurisdiction within the courts listed for jurisdiction above, and the Parties agree to submit to the personal jurisdiction of that court.
 
+<div id="corrections"></div>
 ## **16\. CORRECTIONS**
 
 There may be information on the Services that contains typographical errors, inaccuracies, or omissions, including descriptions, pricing, availability, and variome other information. I reserve the right to correct any errors, inaccuracies, or omissions and to change or update the information on the Services at any time, without prior notice.
 
+<div id="disclaimer"></div>
 ## **17\. DISCLAIMER**
 
 THE SERVICES ARE PROVIDED ON AN AS-IS AND AS-AVAILABLE BASIS. YOU AGREE THAT YOUR USE OF THE SERVICES WILL BE AT YOUR SOLE RISK. TO THE FULLEST EXTENT PERMITTED BY LAW, I DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, IN CONNECTION WITH THE SERVICES AND YOUR USE THEREOF, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. I MAKE NO WARRANTIES OR REPRESENTATIONS ABOUT THE ACCURACY OR COMPLETENESS OF THE SERVICES' CONTENT OR THE CONTENT OF ANY WEBSITES OR MOBILE APPLICATIONS LINKED TO THE SERVICES AND I WILL ASSUME NO LIABILITY OR RESPONSIBILITY FOR ANY (1) ERRORS, MISTAKES, OR INACCURACIES OF CONTENT AND MATERIALS, (2) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO AND USE OF THE SERVICES, (3) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY AND ALL PERSONAL INFORMATION AND/OR FINANCIAL INFORMATION STORED THEREIN, (4) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE SERVICES, (5) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE WHICH MAY BE TRANSMITTED TO OR THROUGH THE SERVICES BY ANY THIRD PARTY, AND/OR (6) ANY ERRORS OR OMISSIONS IN ANY CONTENT AND MATERIALS OR FOR ANY LOSS OR DAMAGE OF ANY KIND INCURRED AS A RESULT OF THE USE OF ANY CONTENT POSTED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE VIA THE SERVICES. I DO NOT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY PRODUCT OR SERVICE ADVERTISED OR OFFERED BY A THIRD PARTY THROUGH THE SERVICES, ANY HYPERLINKED WEBSITE, OR ANY WEBSITE OR MOBILE APPLICATION FEATURED IN ANY BANNER OR OTHER ADVERTISING, AND I WILL NOT BE A PARTY TO OR IN ANY WAY BE RESPONSIBLE FOR MONITORING ANY TRANSACTION BETWEEN YOU AND ANY THIRD-PARTY PROVIDERS OF PRODUCTS OR SERVICES. AS WITH THE PURCHASE OF A PRODUCT OR SERVICE THROUGH ANY MEDIUM OR IN ANY ENVIRONMENT, YOU SHOULD USE YOUR BEST JUDGMENT AND EXERCISE CAUTION WHERE APPROPRIATE.
 
+<div id="liability"></div>
 ## **18\. LIMITATIONS OF LIABILITY**
 
 IN NO EVENT WILL I OR OUR DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT, INDIRECT, CONSEQUENTIAL, EXEMPLARY, INCIDENTAL, SPECIAL, OR PUNITIVE DAMAGES, INCLUDING LOST PROFIT, LOST REVENUE, LOSS OF DATA, OR OTHER DAMAGES ARISING FROM YOUR USE OF THE SERVICES, EVEN IF I HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO YOU FOR ANY CAUSE WHATSOEVER AND REGARDLESS OF THE FORM OF THE ACTION, WILL AT ALL TIMES BE LIMITED TO THE AMOUNT PAID, IF ANY, BY YOU TO US. CERTAIN US STATE LAWS AND INTERNATIONAL LAWS DO NOT ALLOW LIMITATIONS ON IMPLIED WARRANTIES OR THE EXCLUSION OR LIMITATION OF CERTAIN DAMAGES. IF THESE LAWS APPLY TO YOU, SOME OR ALL OF THE ABOVE DISCLAIMERS OR LIMITATIONS MAY NOT APPLY TO YOU, AND YOU MAY HAVE ADDITIONAL RIGHTS.
 
+<div id="indemnification"></div>
 ## **19\. INDEMNIFICATION**
 
 You agree to defend, indemnify, and hold me harmless, including my subsidiaries, affiliates, and all of my respective officers, agents, partners, and employees, from and against any loss, damage, liability, claim, or demand, including reasonable attorneys’ fees and expenses, made by any third party due to or arising out of: (1) your Contributions; (2) use of the Services; (3) breach of these Legal Terms; (4) any breach of your representations and warranties set forth in these Legal Terms; (5) your violation of the rights of a third party, including but not limited to intellectual property rights; or (6) any overt harmful act toward any other user of the Services with whom you connected via the Services. Notwithstanding the foregoing, I reserve the right, at your expense, to assume the exclusive defense and control of any matter for which you are required to indemnify us, and you agree to cooperate, at your expense, with my defense of such claims. I will use reasonable efforts to notify you of any such claim, action, or proceeding which is subject to this indemnification upon becoming aware of it.
 
+<div id="userdata"></div>
 ## **20\. USER DATA**
 
 I will maintain certain data that you transmit to the Services for the purpose of managing the performance of the Services, as well as data relating to your use of the Services. Although I perform regular routine backups of data, you are solely responsible for all data that you transmit or that relates to any activity you have undertaken using the Services. You agree that I shall have no liability to you for any loss or corruption of any such data, and you hereby waive any right of action against me arising from any such loss or corruption of such data.
 
+<div id="electronic"></div>
 ## **21\. ELECTRONIC COMMUNICATIONS, TRANSACTIONS, AND SIGNATURES**
 
 Visiting the Services, sending me emails, and completing online forms constitute electronic communications. You consent to receive electronic communications, and you agree that all agreements, notices, disclosures, and other communications I provide to you electronically, via email and on the Services, satisfy any legal requirement that such communication be in writing. YOU HEREBY AGREE TO THE USE OF ELECTRONIC SIGNATURES, CONTRACTS, ORDERS, AND OTHER RECORDS, AND TO ELECTRONIC DELIVERY OF NOTICES, POLICIES, AND RECORDS OF TRANSACTIONS INITIATED OR COMPLETED BY US OR VIA THE SERVICES. You hereby waive any rights or requirements under any statutes, regulations, rules, ordinances, or other laws in any jurisdiction which require an original signature or delivery or retention of non-electronic records, or to payments or the granting of credits by any means other than electronic means.
 
+<div id="california"></div>
 ## **22\. CALIFORNIA USERS AND RESIDENTS**
 
 If any complaint with me is not satisfactorily resolved, you can contact the Complaint Assistance Unit of the Division of Consumer Services of the California Department of Consumer Affairs in writing at 1625 North Market Blvd., Suite N 112, Sacramento, California 95834 or by telephone at (800) 952-5210 or (916) 445-1254.
 
+<div id="misc"></div>
 ## **23\. MISCELLANEOUS**
 
 These Legal Terms and any policies or operating rules posted by me on the Services or in respect to the Services constitute the entire agreement and understanding between you and us. My failure to exercise or enforce any right or provision of these Legal Terms shall not operate as a waiver of such right or provision. These Legal Terms operate to the fullest extent permissible by law. I may assign any or all of my rights and obligations to others at any time. I shall not be responsible or liable for any loss, damage, delay, or failure to act caused by any cause beyond my reasonable control. If any provision or part of a provision of these Legal Terms is determined to be unlawful, void, or unenforceable, that provision or part of the provision is deemed severable from these Legal Terms and does not affect the validity and enforceability of any remaining provisions. There is no joint venture, partnership, employment or agency relationship created between you and me as a result of these Legal Terms or use of the Services. You agree that these Legal Terms will not be construed against me by virtue of having drafted them. You hereby waive any and all defenses you may have based on the electronic form of these Legal Terms and the lack of signing by the parties hereto to execute these Legal Terms.
 
-**API USAGE AND ACCESS**  
+<div id="addclause"></div>
+## **24. API USAGE AND ACCESS**  
 The publicly available API endpoints provided as part of this service are intended for personal and non-commercial use only. Use of the API for commercial purposes, including but not limited to integrating the API into paid products or services, requires explicit written permission from the owner. Abuse, excessive use, or circumvention of API rate limits is strictly prohibited. The owner reserves the right to revoke or restrict API access at any time, for any reason, without notice. For commercial licensing or access to higher usage limits, please contact lhrh.privat@gmail.com.
 
+<div id="contact"></div>
 ## **25\. CONTACT US**
 
 In order to resolve a complaint regarding the Services or to receive further information regarding use of the Services, please contact me at:


### PR DESCRIPTION
## Summary
- correct several "I are" typos in privacy notice
- add IDs to each Terms of Service section and create API clause heading
- update markdown sources to match new anchors
- link to Privacy Notice and Terms of Service from About page

## Testing
- `git status --short`
