### PR TITLE
Add plane placeholder image

### DIFF
--- a/assets/css/planes.css
+++ b/assets/css/planes.css
@@ -32,6 +32,10 @@
   object-fit: cover;
 }
 
+.plane-photo img.placeholder {
+  object-fit: contain;
+}
+
 .plane-photo span {
   color: #888;
   font-size: 0.9em;

--- a/assets/js/planes.js
+++ b/assets/js/planes.js
@@ -98,7 +98,7 @@ async function loadPlanes() {
             ${
               imgUrl
                 ? `<img src="${imgUrl}" alt="Plane Photo" />`
-                : `<span>No Image</span>`
+                : `<img src="assets/img/noimage.png" alt="No Image" class="placeholder" />`
             }
           </div>
           <div class="plane-info" data-id="${plane._id}" data-note="${plane.note ? encodeURIComponent(plane.note) : ''}">
@@ -158,7 +158,7 @@ document.addEventListener("click", (e) => {
           ${
             img
               ? `<img src="${img}" alt="Plane Photo" />`
-              : `<span>No Image</span>`
+              : `<img src="assets/img/noimage.png" alt="No Image" class="placeholder" />`
           }
         </div>
         <div class="plane-details">


### PR DESCRIPTION
## Summary
- show `assets/img/noimage.png` when a plane has no photo
- use same placeholder in fullscreen mode
- style placeholder images to fit within the gray box

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68421db722dc832fb5a54634561fcc9d