### PR TITLE
Display fitness scores in user page

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -164,3 +164,17 @@ main.center {
 .status-green {
   color: darkgreen;
 }
+
+/* Fitness score text sizes */
+#fitnessScores {
+  margin-top: 10px;
+  text-align: center;
+}
+#fitnessScore {
+  font-size: 1.6em;
+  font-weight: 600;
+}
+#experienceScore,
+#recencyScore {
+  font-size: 1em;
+}

--- a/assets/js/user.js
+++ b/assets/js/user.js
@@ -84,6 +84,25 @@ async function loadFitnessInfo() {
 
     const hours12 = minutes12 / 60;
 
+    // ----- Fitness Score Calculations -----
+    const flightsScore = Math.min(flights12 / 50, 1.0);
+    const hoursScore = Math.min(hours12 / 100, 1.0);
+    const experienceScore = (flightsScore + hoursScore) / 2;
+
+    const daysSince = Math.floor((now - lastFlightDate) / (1000 * 60 * 60 * 24));
+    const baseK = 0.05;
+    const adjustedK = baseK / (0.5 + 0.5 * experienceScore);
+    const rawRecency = Math.exp(-adjustedK * daysSince);
+    const recencyScore = rawRecency * (0.5 + 0.5 * experienceScore);
+    const fitnessScore = 0.5 * recencyScore + 0.5 * experienceScore;
+
+    document.getElementById("fitnessScore").textContent =
+      `Fitness Score: ${fitnessScore.toFixed(3)}`;
+    document.getElementById("experienceScore").textContent =
+      `Experience: ${experienceScore.toFixed(3)}`;
+    document.getElementById("recencyScore").textContent =
+      `Recency: ${recencyScore.toFixed(3)}`;
+
     setStatus(
       "lastFlightDate",
       formatDateOnly(lastFlightDate),

--- a/user.html
+++ b/user.html
@@ -69,6 +69,11 @@
                 <span id="airtime12m">-</span>
               </p>
               <p id="fitMessage"></p>
+              <div id="fitnessScores">
+                <p id="fitnessScore">Loading...</p>
+                <p id="experienceScore"></p>
+                <p id="recencyScore"></p>
+              </div>
             </div>
 
             <!-- Widget: Log Out -->


### PR DESCRIPTION
## Summary
- show pilot fitness score breakdown in profile page
- style score numbers so overall fitness appears larger

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6845c7e90cb0832fac1883aa63add0be