### PR TITLE
Improve fit widget display and help

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -161,9 +161,13 @@ main.center {
 
 /* Fitness score text sizes */
 #fitDetails p {
-  margin: 5px;
+  margin: 5px 0;
   display: flex;
-  align-items: space-between;
+  justify-content: space-between;
+}
+#fitDetails p span {
+  margin-left: auto;
+  text-align: right;
 }
 
 #fitnessScores {
@@ -205,9 +209,3 @@ main.center {
   display: none;
 }
 
-#scoreHelp {
-  font-size: 0.9em;
-  margin-top: 5px;
-  text-align: left;
-  color: #555;
-}

--- a/assets/css/widgets.css
+++ b/assets/css/widgets.css
@@ -99,6 +99,10 @@
     background: none;
     border: none;
   }
+  #widgetModal pre {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
   .dark-mode #closeModalBtn {
     color: white;
   }

--- a/assets/css/widgets.css
+++ b/assets/css/widgets.css
@@ -71,6 +71,7 @@
   
   #widgetModal .modal-content {
     width: min(90vw, max(60vw, 500px));
+    max-height: 90vh;
     padding: 30px;
     overflow-y: auto;
     background: white;

--- a/assets/js/user.js
+++ b/assets/js/user.js
@@ -332,7 +332,13 @@ Recency Score = Raw Recency Score * (0.5 + 0.5 * Experience Score)
 This makes it super easy for pilots to **self-evaluate** and for instructors to **guide** them.`;
 
 const scoreHelpHTML = `<h3>Fitness Scores Explained</h3>
-<p><em>Quick version:</em> Higher scores mean you're more current. Experience counts flights and hours in the last year. Recency measures how long since you flew last. The Fitness Score is the average of the two.</p>
+<p><em>Quick overview:</em></p>
+<ul>
+  <li><strong>Fitness (F)</strong> – overall score, averaging E and R.</li>
+  <li><strong>Experience (E)</strong> – flights and hours logged in the last year.</li>
+  <li><strong>Recency (R)</strong> – decays with days since last flight; drops slower if you have more experience.</li>
+</ul>
+<p>Scores range from 0–100. Higher values mean you're more current. Use the Fitness score to judge if more practice is needed.</p>
 ${simpleMarkdown(scoreHelpText.replace(/```/g, ""))}`;
 
 document.querySelectorAll(".fullscreen-btn").forEach((btn) => {

--- a/assets/js/user.js
+++ b/assets/js/user.js
@@ -69,8 +69,8 @@ async function loadFitnessInfo() {
 
     const now = new Date();
     const lastFlightDate = new Date(getEntryDate(flights[0]));
-    const diffMonths = (now - lastFlightDate) / (1000 * 60 * 60 * 24 * 30);
-    const monthsSince = Math.floor(diffMonths);
+    const daysSince = Math.floor((now - lastFlightDate) / (1000 * 60 * 60 * 24));
+    const monthsSince = Math.floor(daysSince / 30);
 
     const yearAgo = new Date();
     yearAgo.setFullYear(yearAgo.getFullYear() - 1);
@@ -92,9 +92,6 @@ async function loadFitnessInfo() {
     const hoursScore = Math.min(hours12 / 100, 1.0);
     const experienceScore = (flightsScore + hoursScore) / 2;
 
-    const daysSince = Math.floor(
-      (now - lastFlightDate) / (1000 * 60 * 60 * 24)
-    );
     const baseK = 0.05;
     const adjustedK = baseK / (0.5 + 0.5 * experienceScore);
     const rawRecency = Math.exp(-adjustedK * daysSince);
@@ -111,10 +108,7 @@ async function loadFitnessInfo() {
       recencyScore * 100
     )}`;
 
-    const agoText =
-      monthsSince >= 1
-        ? `${monthsSince} month${monthsSince > 1 ? "s" : ""} ago`
-        : "<1 month ago";
+    const agoText = `${daysSince} day${daysSince !== 1 ? "s" : ""}`;
     setStatus("lastFlightAgo", agoText, severityFromMonths(monthsSince));
 
     setStatus("flights12m", flights12, severityFromFlights(flights12));
@@ -339,7 +333,7 @@ This makes it super easy for pilots to **self-evaluate** and for instructors to 
 
 const scoreHelpHTML = `<h3>Fitness Scores Explained</h3>
 <p><em>Quick version:</em> Higher scores mean you're more current. Experience counts flights and hours in the last year. Recency measures how long since you flew last. The Fitness Score is the average of the two.</p>
-<pre>${scoreHelpText}</pre>`;
+${simpleMarkdown(scoreHelpText.replace(/```/g, ""))}`;
 
 document.querySelectorAll(".fullscreen-btn").forEach((btn) => {
   btn.addEventListener("click", (e) => {

--- a/assets/js/user.js
+++ b/assets/js/user.js
@@ -111,15 +111,11 @@ async function loadFitnessInfo() {
       recencyScore * 100
     )}`;
 
-    setStatus(
-      "lastFlightDate",
-      formatDateOnly(lastFlightDate),
-      severityFromMonths(monthsSince)
-    );
-    document.getElementById("lastFlightAgo").textContent =
+    const agoText =
       monthsSince >= 1
-        ? `${monthsSince} month${monthsSince > 1 ? "s" : ""}`
-        : "<1 month";
+        ? `${monthsSince} month${monthsSince > 1 ? "s" : ""} ago`
+        : "<1 month ago";
+    setStatus("lastFlightAgo", agoText, severityFromMonths(monthsSince));
 
     setStatus("flights12m", flights12, severityFromFlights(flights12));
     setStatus(
@@ -221,6 +217,130 @@ document.getElementById("editProfileButton")?.addEventListener("click", () => {
 const modal = document.getElementById("widgetModal");
 const modalContent = document.getElementById("modalContent");
 
+const scoreHelpText = `# Pilot Fitness Score System
+
+This scoring system helps pilots understand their flight fitness by looking at three key metrics:
+
+1. **Fitness Score** – Overall flying fitness (0.0 to 1.0).
+2. **Experience Score** – Measures the pilot’s total activity over the past 12 months.
+3. **Recency Score** – Measures how recently the pilot last flew, with an adjustment for experience.
+
+---
+
+## 1️ Fitness Score
+
+**What is it?**
+
+* The main score showing the pilot’s overall flight fitness.
+
+**Formula:**
+
+Fitness Score = (Weight_Recency * Recency Score)
+              + (Weight_Experience * Experience Score)
+
+**Default Weights:**
+
+* Weight_Recency = 0.5
+* Weight_Experience = 0.5
+
+---
+
+## 2️ Experience Score
+
+**What is it?**
+
+* Measures overall flying activity over the last 12 months.
+* Higher = more experienced pilot.
+
+**Formula:**
+
+Flights Score = min(Flights in 12m / 50, 1.0)
+Hours Score = min(Hours in 12m / 100, 1.0)
+Experience Score = (Flights Score + Hours Score) / 2
+
+**Notes:**
+
+* 50 flights/year = very active.
+* 100 hours/year = very experienced.
+
+---
+
+## 3️ Recency Score
+
+**What is it?**
+
+* Measures how recently the pilot last flew.
+* Adjusts for experience — high-experience pilots decay slower.
+
+**Steps:**
+
+### 1. Calculate the **Adjusted Decay Rate (k):**
+
+Adjusted k = Base k / (0.5 + 0.5 * Experience Score)
+
+* Base k (default) = 0.05
+* Higher experience → lower decay rate.
+
+### 2. Calculate the **Raw Recency Score:**
+
+Raw Recency Score = exp(-Adjusted k * Days Since Last Flight)
+
+* Days Since Last Flight = number of days since the pilot’s last flight.
+
+### 3. Scale the **Raw Recency Score** by experience to get the final Recency Score:
+
+Recency Score = Raw Recency Score * (0.5 + 0.5 * Experience Score)
+
+* This prevents low-experience pilots from getting a perfect score from just one flight.
+
+---
+
+## Putting It All Together
+
+**Example:**
+
+* Days Since Last Flight: 30
+* Flights in 12m: 10
+* Hours in 12m: 20
+
+### Experience Score:
+
+* Flights Score = min(10/50, 1.0) = 0.2
+* Hours Score = min(20/100, 1.0) = 0.2
+* Experience Score = (0.2 + 0.2) / 2 = 0.2
+
+### Adjusted k:
+
+* Adjusted k = 0.05 / (0.5 + 0.5 * 0.2) ≈ 0.083
+
+### Raw Recency Score:
+
+* Raw Recency Score = exp(-0.083 * 30) ≈ 0.082
+
+### Final Recency Score:
+
+* Recency Score = 0.082 * (0.5 + 0.5 * 0.2) ≈ 0.049
+
+### Fitness Score:
+
+* Fitness Score = 0.5 * 0.049 + 0.5 * 0.2 = 0.1245
+
+---
+
+## Summary
+
+| Score         | Purpose                          |
+| ------------- | -------------------------------- |
+| Fitness Score | Overall flying fitness.          |
+| Experience    | Shows total flying in 12 months. |
+| Recency       | Shows how fresh the pilot is.    |
+
+This makes it super easy for pilots to **self-evaluate** and for instructors to **guide** them.`;
+
+const scoreHelpHTML = `<h3>Fitness Scores Explained</h3>
+<p><em>Quick version:</em> Higher scores mean you're more current. Experience counts flights and hours in the last year. Recency measures how long since you flew last. The Fitness Score is the average of the two.</p>
+<pre>${scoreHelpText}</pre>`;
+
 document.querySelectorAll(".fullscreen-btn").forEach((btn) => {
   btn.addEventListener("click", (e) => {
     const widget = e.target.closest(".widget");
@@ -249,8 +369,8 @@ document.addEventListener("keydown", (e) => {
 
 // Score help toggle
 document.getElementById("scoreHelpBtn")?.addEventListener("click", () => {
-  const help = document.getElementById("scoreHelp");
-  help.classList.toggle("hidden");
+  modalContent.innerHTML = scoreHelpHTML;
+  modal.style.display = "flex";
 });
 
 // Logout

--- a/user.html
+++ b/user.html
@@ -84,10 +84,7 @@
               <div id="fitDetails">
                 <p>
                   <strong>Last flight:</strong>
-                  <span id="lastFlightDate">-</span>
-                  (
                   <span id="lastFlightAgo">-</span>
-                  ago)
                 </p>
                 <p>
                   <strong>Flights last 12 months:</strong>
@@ -98,20 +95,6 @@
                   <span id="airtime12m">-</span>
                 </p>
                 <p id="fitMessage"></p>
-                <div id="scoreHelp" class="hidden">
-                  <p>
-                    <strong>Fitness Score</strong>
-                    &ndash; your overall flight fitness.
-                  </p>
-                  <p>
-                    <strong>Experience Score</strong>
-                    &ndash; total flying activity over the past year.
-                  </p>
-                  <p>
-                    <strong>Recency Score</strong>
-                    &ndash; how recently you flew, scaled by experience.
-                  </p>
-                </div>
               </div>
             </div>
 

--- a/user.html
+++ b/user.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="assets/css/nav.css" />
     <link rel="stylesheet" href="assets/css/darkmode.css" />
     <link rel="stylesheet" href="assets/css/widgets.css" />
+    <link rel="stylesheet" href="assets/css/about.css" />
     <script defer src="assets/js/header.js"></script>
     <script defer src="assets/js/user-menu.js"></script>
   </head>
@@ -129,6 +130,7 @@
 
     <!-- Scripts -->
     <script src="assets/js/nav.js" defer></script>
+    <script src="assets/js/simpleMarkdown.js"></script>
     <script src="assets/js/user.js" defer></script>
     <script src="assets/js/darkmode.js" defer></script>
   </body>


### PR DESCRIPTION
## Summary
- align fit widget details for better readability
- show relative time since last flight
- add detailed fitness scoring explanation in a modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6845d4a2c7a8832fbeade1df8cfd7a52