### PR TITLE
Enhance fitness history with E/R scores

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -209,3 +209,14 @@ main.center {
   display: none;
 }
 
+#fitnessHistoryChart {
+  width: 100%;
+  max-height: 300px;
+  margin-top: 10px;
+}
+
+#historyRangeSelect {
+  margin-top: 5px;
+  width: 100%;
+}
+

--- a/user.html
+++ b/user.html
@@ -131,6 +131,7 @@
     <!-- Scripts -->
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/simpleMarkdown.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="assets/js/user.js" defer></script>
     <script src="assets/js/darkmode.js" defer></script>
   </body>


### PR DESCRIPTION
## Summary
- track experience and recency scores in daily history calculations
- compute 60‑day moving averages for all scores
- render fitness, experience, and recency graphs with smoothed trend lines
- hide the help button in fullscreen view

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6845dddb4134832f9e08c7714e5b0dc7