### PR TITLE
Enhance user page stats and layout

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -170,6 +170,15 @@ main.center {
   text-align: right;
 }
 
+#statsDetails p {
+  margin: 5px 0;
+  display: flex;
+  justify-content: space-between;
+}
+#statsDetails p span {
+  margin-left: auto;
+  text-align: right;
+}
 #fitnessScores {
   display: flex;
   flex-direction: initial;

--- a/assets/js/user.js
+++ b/assets/js/user.js
@@ -314,10 +314,10 @@ function planeLabel(flight) {
 }
 
 function updateStats() {
-  const list = document.getElementById("statsList");
-  if (!list) return;
+  const details = document.getElementById("statsDetails");
+  if (!details) return;
   if (!userFlights.length) {
-    list.innerHTML = "<li>No flights logged yet.</li>";
+    details.innerHTML = "<p>No flights logged yet.</p>";
     return;
   }
 
@@ -331,30 +331,37 @@ function updateStats() {
   );
 
   const planeCounts = {};
+  const planeMinutes = {};
   const baseCounts = {};
   let longest = 0;
   userFlights.forEach((f) => {
     const count = getFlightCount(f);
     const minutes = getFlightMinutes(f);
     const plane = planeLabel(f);
-    if (plane) planeCounts[plane] = (planeCounts[plane] || 0) + count;
+    if (plane) {
+      planeCounts[plane] = (planeCounts[plane] || 0) + count;
+      planeMinutes[plane] = (planeMinutes[plane] || 0) + minutes;
+    }
     const base = (f.startLocation || "").toUpperCase();
     if (base) baseCounts[base] = (baseCounts[base] || 0) + count;
     if (minutes > longest) longest = minutes;
   });
 
-  const favPlane = Object.entries(planeCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || "-";
-  const favBase = Object.entries(baseCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || "-";
+  const favPlaneFlights =
+    Object.entries(planeCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || "-";
+  const favPlaneTime =
+    Object.entries(planeMinutes).sort((a, b) => b[1] - a[1])[0]?.[0] || "-";
+  const favBase =
+    Object.entries(baseCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || "-";
 
   const formatDur = (m) => `${Math.floor(m / 60)}h ${m % 60}m`;
 
-  list.innerHTML = `
-    <li>Total flights: ${totalFlights}</li>
-    <li>Total air time: ${formatDur(totalMinutes)}</li>
-    <li>Favorite plane: ${favPlane}</li>
-    <li>Favorite airbase: ${favBase}</li>
-    <li>Longest flight: ${formatDur(longest)}</li>
-  `;
+  document.getElementById("statTotalFlights").textContent = totalFlights;
+  document.getElementById("statTotalMinutes").textContent = formatDur(totalMinutes);
+  document.getElementById("statFavPlaneFlights").textContent = favPlaneFlights;
+  document.getElementById("statFavPlaneTime").textContent = favPlaneTime;
+  document.getElementById("statFavBase").textContent = favBase;
+  document.getElementById("statLongest").textContent = formatDur(longest);
 }
 
 loadFitnessInfo();

--- a/assets/js/user.js
+++ b/assets/js/user.js
@@ -6,6 +6,8 @@ if (!token) {
 
 // Store flights for later calculations
 let userFlights = [];
+// Cache plane display names by id
+let cachedPlanes = {};
 
 // Fetch and display user data
 async function loadUserInfo() {
@@ -35,6 +37,15 @@ async function loadUserInfo() {
     const firstName = data.name || "";
     const header = document.getElementById("userInfoHeader");
     if (header) header.textContent = `👤 ${firstName}`;
+
+    // Cache planes for later lookup
+    if (Array.isArray(data.planes)) {
+      data.planes.forEach((plane) => {
+        if (plane && plane._id) {
+          cachedPlanes[plane._id] = plane;
+        }
+      });
+    }
   } catch (err) {
     console.error("Error fetching user info:", err);
     document.getElementById("userName").textContent = "Guest";
@@ -307,6 +318,19 @@ function smoothHistory(history, windowSize = 60) {
 }
 
 function planeLabel(flight) {
+  // If manual plane entry, prefer the name or registration
+  if (flight.manualPlane) {
+    if (flight.displayName) return flight.displayName;
+    if (flight.registration) return flight.registration;
+  }
+
+  // Lookup cached planes by id
+  if (flight.plane_id && cachedPlanes[flight.plane_id]) {
+    const plane = cachedPlanes[flight.plane_id];
+    if (plane.displayName) return plane.displayName;
+    if (plane.registration) return plane.registration;
+  }
+
   if (flight.displayName) return flight.displayName;
   if (flight.registration) return flight.registration;
   if (flight.plane_id) return flight.plane_id.substring(0, 6);

--- a/assets/js/user.js
+++ b/assets/js/user.js
@@ -45,6 +45,8 @@ async function loadUserInfo() {
           cachedPlanes[plane._id] = plane;
         }
       });
+      // Refresh stats in case flights loaded first
+      updateStats();
     }
   } catch (err) {
     console.error("Error fetching user info:", err);

--- a/user.html
+++ b/user.html
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="assets/css/nav.css" />
     <link rel="stylesheet" href="assets/css/darkmode.css" />
     <link rel="stylesheet" href="assets/css/widgets.css" />
-    <link rel="stylesheet" href="assets/css/about.css" />
     <script defer src="assets/js/header.js"></script>
     <script defer src="assets/js/user-menu.js"></script>
   </head>
@@ -33,7 +32,7 @@
                 </button>
                 <button class="fullscreen-btn" title="Fullscreen">⛶</button>
               </div>
-              <h3>👤 Basic Information</h3>
+              <h3 id="userInfoHeader">👤</h3>
               <p>
                 <strong>Name:</strong>
                 <span id="userName">Loading...</span>
@@ -42,16 +41,18 @@
                 <strong>Email:</strong>
                 <span id="userEmail">Loading...</span>
               </p>
-            </div>
-
-            <!-- Widget: Stats (Placeholder) -->
-            <div class="widget" id="statsWidget">
-              <div class="widget-buttons">
-                <!-- <button class="edit-btn" title="Edit">✏️</button> -->
-                <button class="fullscreen-btn" title="Fullscreen">⛶</button>
-              </div>
-              <h3>📈 Your Stats</h3>
-              <p>Coming soon...</p>
+              <button
+                id="logoutButton"
+                style="
+                  margin-top: 10px;
+                  width: 50%;
+                  height: 35px;
+                  color: darkred;
+                  border-color: darkred;
+                  border-radius: inherit;
+                ">
+                Log Out
+              </button>
             </div>
 
             <!-- Widget: Fit for flying? -->
@@ -99,22 +100,15 @@
               </div>
             </div>
 
-            <!-- Widget: Log Out -->
-            <div class="widget" id="logoutWidget">
-              <h3>🚪 Log Out</h3>
-              <button
-                id="logoutButton"
-                style="
-                  margin-top: 10px;
-                  width: 50%;
-                  height: 35px;
-                  color: darkred;
-                  border-color: darkred;
-                  border-radius: inherit;
-                ">
-                Log Out
-              </button>
+            <!-- Widget: Stats -->
+            <div class="widget" id="statsWidget">
+              <div class="widget-buttons">
+                <button class="fullscreen-btn" title="Fullscreen">⛶</button>
+              </div>
+              <h3>📈 Your Stats</h3>
+              <ul id="statsList"></ul>
             </div>
+
           </div>
         </section>
       </main>

--- a/user.html
+++ b/user.html
@@ -106,7 +106,32 @@
                 <button class="fullscreen-btn" title="Fullscreen">⛶</button>
               </div>
               <h3>📈 Your Stats</h3>
-              <ul id="statsList"></ul>
+              <div id="statsDetails">
+                <p>
+                  <strong>Total flights:</strong>
+                  <span id="statTotalFlights">-</span>
+                </p>
+                <p>
+                  <strong>Total air time:</strong>
+                  <span id="statTotalMinutes">-</span>
+                </p>
+                <p>
+                  <strong>Favorite plane (flights):</strong>
+                  <span id="statFavPlaneFlights">-</span>
+                </p>
+                <p>
+                  <strong>Favorite plane (time):</strong>
+                  <span id="statFavPlaneTime">-</span>
+                </p>
+                <p>
+                  <strong>Favorite airbase:</strong>
+                  <span id="statFavBase">-</span>
+                </p>
+                <p>
+                  <strong>Longest flight:</strong>
+                  <span id="statLongest">-</span>
+                </p>
+              </div>
             </div>
 
           </div>


### PR DESCRIPTION
## Summary
- remove about.css from user profile page to fix dark‑mode background
- move logout button into the basic info widget and remove the logout widget
- rename basic info heading with the pilot's first name
- show "Fit for flight" before the stats widget
- populate stats widget with logbook statistics

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6845eeb0fde8832f802e245b805a2d4c