### PR TITLE
Add certifications widget to user page

### DIFF
--- a/assets/css/forms.css
+++ b/assets/css/forms.css
@@ -142,6 +142,18 @@ body.dark-mode .close-btn:hover {
   margin-top: 20px;
 }
 
+/* Inline checkbox fields */
+.edit-form .checkbox-field {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+.edit-form .checkbox-field input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+}
+
 /* Ensure hidden fields remain hidden inside edit forms */
 .edit-form .hidden {
   display: none;

--- a/assets/css/forms.css
+++ b/assets/css/forms.css
@@ -142,6 +142,11 @@ body.dark-mode .close-btn:hover {
   margin-top: 20px;
 }
 
+/* Ensure hidden fields remain hidden inside edit forms */
+.edit-form .hidden {
+  display: none;
+}
+
 #imageControls {
   display: flex;
   gap: 10px;

--- a/assets/css/widgets.css
+++ b/assets/css/widgets.css
@@ -203,4 +203,8 @@
   display: flex;
   gap: 6px;
 }
-  
+  .cert-status.revoked { color: #d00; }
+.cert-status.expired { color: gray; }
+.cert-status.pending { color: #4ea5ff; }
+.cert-status.active { color: green; }
+.cert-status.expires-soon { color: orange; }

--- a/assets/css/widgets.css
+++ b/assets/css/widgets.css
@@ -203,7 +203,14 @@
   display: flex;
   gap: 6px;
 }
-  .cert-status.revoked { color: #d00; }
+.cert-actions .edit-cert-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+}
+.cert-status.revoked { color: #d00; }
 .cert-status.expired { color: gray; }
 .cert-status.pending { color: #4ea5ff; }
 .cert-status.active { color: green; }

--- a/assets/css/widgets.css
+++ b/assets/css/widgets.css
@@ -181,7 +181,26 @@
   /* ICAO form locking when disabled */
   /* ─────────────────────────────────────────────────────────────── */
   #icaoForm input[disabled],
-  #icaoForm button[disabled] {
-    display: none;
-  }
+#icaoForm button[disabled] {
+  display: none;
+}
+
+/* ─────────────────────────────────────────────────────────────── */
+/* Certification list styling                                       */
+/* ─────────────────────────────────────────────────────────────── */
+.cert-item {
+  padding: 6px 0;
+  border-bottom: 1px solid #ccc;
+  position: relative;
+}
+.cert-item:last-child {
+  border-bottom: none;
+}
+.cert-actions {
+  position: absolute;
+  top: 2px;
+  right: 0;
+  display: flex;
+  gap: 6px;
+}
   

--- a/assets/js/certifications.js
+++ b/assets/js/certifications.js
@@ -29,7 +29,7 @@ async function loadCertifications() {
     if (!data.success) throw new Error(data.message || "Failed to load");
     const certs = Array.isArray(data.certifications) ? data.certifications : [];
     if (!certs.length) {
-      certListEl.innerHTML = "<p>No certifications added.</p>";
+      certListEl.innerHTML = "<p>No certifications added yet.</p>";
       return;
     }
     certListEl.innerHTML = "";
@@ -131,26 +131,34 @@ async function deleteCertification(id) {
   }
 }
 
-document.getElementById("addCertBtn")?.addEventListener("click", () => {
-  showCertForm();
-});
+document.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("addCertBtn")?.addEventListener("click", () => {
+    showCertForm();
+  });
 
-certListEl?.addEventListener("click", (e) => {
-  const editBtn = e.target.closest(".edit-cert-btn");
-  const delBtn = e.target.closest(".delete-cert-btn");
-  const item = e.target.closest(".cert-item");
-  if (!item) return;
-  const id = item.dataset.id;
-  if (editBtn) {
-    const name = item.querySelector("strong")?.textContent || "";
-    const status = item.querySelector("em")?.textContent.replace(/[()]/g, "") || "";
-    const [issue, valid] = item
-      .querySelector("small")
-      ?.textContent.split(" - ") || ["", ""];
-    showCertForm({ _id: id, name, status, issueDate: issue, validUntilDate: valid });
-  } else if (delBtn) {
-    deleteCertification(id);
-  }
-});
+  certListEl?.addEventListener("click", (e) => {
+    const editBtn = e.target.closest(".edit-cert-btn");
+    const delBtn = e.target.closest(".delete-cert-btn");
+    const item = e.target.closest(".cert-item");
+    if (!item) return;
+    const id = item.dataset.id;
+    if (editBtn) {
+      const name = item.querySelector("strong")?.textContent || "";
+      const status = item
+        .querySelector("em")?.textContent.replace(/[()]/g, "") || "";
+      const [issue, valid] =
+        item.querySelector("small")?.textContent.split(" - ") || ["", ""];
+      showCertForm({
+        _id: id,
+        name,
+        status,
+        issueDate: issue,
+        validUntilDate: valid,
+      });
+    } else if (delBtn) {
+      deleteCertification(id);
+    }
+  });
 
-loadCertifications();
+  loadCertifications();
+});

--- a/assets/js/certifications.js
+++ b/assets/js/certifications.js
@@ -66,9 +66,16 @@ async function loadCertifications() {
       div.dataset.revoked = !!c.revoked;
       div.dataset.issueDate = c.issueDate || "";
       div.dataset.validUntilDate = c.validUntilDate || "";
+
       const status = determineStatus(c);
+      const base = status.split(",")[0].trim();
+      let cls = base;
+      if (status.includes("expires soon")) {
+        cls += " expires-soon";
+      }
+
       div.innerHTML = `
-        <strong>${c.name}</strong> <em>(${status})</em><br/>
+        <strong>${c.name}</strong> <em class="cert-status ${cls}">(${status})</em><br/>
         <small>${formatDate(c.issueDate)} - ${formatDate(c.validUntilDate)}</small>
         <div class="cert-actions">
           <button class="edit-cert-btn" title="Edit">✏️</button>

--- a/assets/js/certifications.js
+++ b/assets/js/certifications.js
@@ -1,12 +1,13 @@
 // Manage pilot certifications on the user page
-const token = localStorage.getItem("jwtToken");
-if (!token) {
-  window.location.href = "/login";
-}
+(function () {
+  const token = localStorage.getItem("jwtToken");
+  if (!token) {
+    window.location.href = "/login";
+  }
 
-const certListEl = document.getElementById("certList");
-const modal = document.getElementById("widgetModal");
-const modalContent = document.getElementById("modalContent");
+  const certListEl = document.getElementById("certList");
+  const modal = document.getElementById("widgetModal");
+  const modalContent = document.getElementById("modalContent");
 
 function formatDate(dateStr) {
   if (!dateStr) return "-";
@@ -165,5 +166,6 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 });
 
-// Immediately load certifications when the script executes
-loadCertifications();
+  // Immediately load certifications when the script executes
+  loadCertifications();
+})();

--- a/assets/js/certifications.js
+++ b/assets/js/certifications.js
@@ -1,0 +1,156 @@
+// Manage pilot certifications on the user page
+const token = localStorage.getItem("jwtToken");
+if (!token) {
+  window.location.href = "/login";
+}
+
+const certListEl = document.getElementById("certList");
+const modal = document.getElementById("widgetModal");
+const modalContent = document.getElementById("modalContent");
+
+function formatDate(dateStr) {
+  if (!dateStr) return "-";
+  const d = new Date(dateStr);
+  if (isNaN(d)) return "-";
+  return d.toISOString().split("T")[0];
+}
+
+async function loadCertifications() {
+  if (!certListEl) return;
+  certListEl.innerHTML = "<p>Loading...</p>";
+  try {
+    const res = await fetch(
+      `https://n8n.e57.dk/webhook/pilot-dashboard/get-certification?token=${encodeURIComponent(
+        token
+      )}`
+    );
+    if (!res.ok) throw new Error("Failed to fetch");
+    const [data] = await res.json();
+    if (!data.success) throw new Error(data.message || "Failed to load");
+    const certs = Array.isArray(data.certifications) ? data.certifications : [];
+    if (!certs.length) {
+      certListEl.innerHTML = "<p>No certifications added.</p>";
+      return;
+    }
+    certListEl.innerHTML = "";
+    certs.forEach((c) => {
+      const div = document.createElement("div");
+      div.className = "cert-item";
+      div.dataset.id = c._id;
+      div.innerHTML = `
+        <strong>${c.name}</strong> <em>(${c.status})</em><br/>
+        <small>${formatDate(c.issueDate)} - ${formatDate(c.validUntilDate)}</small>
+        <div class="cert-actions">
+          <button class="edit-cert-btn" title="Edit">✏️</button>
+          <button class="delete-cert-btn" title="Delete">🗑</button>
+        </div>`;
+      certListEl.appendChild(div);
+    });
+  } catch (err) {
+    console.error(err);
+    certListEl.innerHTML = "<p style='color:red;'>Could not load certifications.</p>";
+  }
+}
+
+function showCertForm(opts = {}) {
+  const isEdit = !!opts._id;
+  modalContent.innerHTML = `
+    <form id="certForm" class="edit-form">
+      <h2 style="text-align:center;">${isEdit ? "Edit" : "Add"} Certification</h2>
+      ${isEdit ? `<input type="hidden" id="certId" value="${opts._id}">` : ""}
+      <label>Name
+        <input type="text" id="certName" value="${opts.name || ""}" required>
+      </label>
+      <label>Status
+        <input type="text" id="certStatus" value="${opts.status || ""}" required>
+      </label>
+      <label>Issue Date
+        <input type="date" id="certIssue" value="${formatDate(opts.issueDate) !== "-" ? formatDate(opts.issueDate) : ""}" required>
+      </label>
+      <label>Valid Until
+        <input type="date" id="certValid" value="${formatDate(opts.validUntilDate) !== "-" ? formatDate(opts.validUntilDate) : ""}" required>
+      </label>
+      <button type="submit">${isEdit ? "Save" : "Add"}</button>
+    </form>`;
+  modal.style.display = "flex";
+
+  document.getElementById("certForm")?.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const payload = {
+      token,
+      name: document.getElementById("certName").value.trim(),
+      status: document.getElementById("certStatus").value.trim(),
+      issueDate: document.getElementById("certIssue").value,
+      validUntilDate: document.getElementById("certValid").value,
+    };
+    try {
+      let url = "https://n8n.e57.dk/webhook/pilot-dashboard/add-certification";
+      if (isEdit) {
+        url = "https://n8n.e57.dk/webhook/pilot-dashboard/edit-certification";
+        payload.certification_id = opts._id;
+      }
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const text = await res.text();
+      const result = text ? JSON.parse(text) : {};
+      if (!res.ok || result.success === false) {
+        throw new Error(result.message || "Request failed");
+      }
+      modal.style.display = "none";
+      await loadCertifications();
+    } catch (err) {
+      console.error(err);
+      alert(err.message || "Failed");
+    }
+  });
+}
+
+async function deleteCertification(id) {
+  if (!confirm("Delete this certification?")) return;
+  try {
+    const res = await fetch(
+      "https://n8n.e57.dk/webhook/pilot-dashboard/delete-certification",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, certification_id: id }),
+      }
+    );
+    const text = await res.text();
+    const result = text ? JSON.parse(text) : {};
+    if (!res.ok || result.success === false) {
+      throw new Error(result.message || "Delete failed");
+    }
+    await loadCertifications();
+  } catch (err) {
+    console.error(err);
+    alert(err.message || "Failed to delete");
+  }
+}
+
+document.getElementById("addCertBtn")?.addEventListener("click", () => {
+  showCertForm();
+});
+
+certListEl?.addEventListener("click", (e) => {
+  const editBtn = e.target.closest(".edit-cert-btn");
+  const delBtn = e.target.closest(".delete-cert-btn");
+  const item = e.target.closest(".cert-item");
+  if (!item) return;
+  const id = item.dataset.id;
+  if (editBtn) {
+    const name = item.querySelector("strong")?.textContent || "";
+    const status = item.querySelector("em")?.textContent.replace(/[()]/g, "") || "";
+    const [issue, valid] = item
+      .querySelector("small")
+      ?.textContent.split(" - ") || ["", ""];
+    showCertForm({ _id: id, name, status, issueDate: issue, validUntilDate: valid });
+  } else if (delBtn) {
+    deleteCertification(id);
+  }
+});
+
+loadCertifications();

--- a/assets/js/certifications.js
+++ b/assets/js/certifications.js
@@ -192,6 +192,7 @@ async function deleteCertification(id) {
     if (!res.ok || result.success === false) {
       throw new Error(result.message || "Delete failed");
     }
+    modal.style.display = "none";
     await loadCertifications();
   } catch (err) {
     console.error(err);

--- a/assets/js/certifications.js
+++ b/assets/js/certifications.js
@@ -149,7 +149,7 @@ function showCertForm(opts = {}) {
       let url;
       let body;
       if (isEdit) {
-        url = "https://n8n.e57.dk/webhook/pilot-dashboard/edit-certification";
+        url = "https://n8n.e57.dk/webhook/pilot-dashboard/update-certification";
         body = JSON.stringify({ token, cert_id: opts._id, updates });
       } else {
         url = "https://n8n.e57.dk/webhook/pilot-dashboard/add-certification";

--- a/assets/js/certifications.js
+++ b/assets/js/certifications.js
@@ -19,16 +19,20 @@ async function loadCertifications() {
   if (!certListEl) return;
   certListEl.innerHTML = "<p>Loading...</p>";
   try {
-    const res = await fetch(
-      `https://n8n.e57.dk/webhook/pilot-dashboard/get-certification?token=${encodeURIComponent(
-        token
-      )}`
-    );
+    const url =
+      "https://n8n.e57.dk/webhook/pilot-dashboard/get-certification?token=" +
+      encodeURIComponent(token);
+    const res = await fetch(url);
     if (!res.ok) throw new Error("Failed to fetch");
     const [data] = await res.json();
     if (!data.success) throw new Error(data.message || "Failed to load");
-    const certs = Array.isArray(data.certifications) ? data.certifications : [];
-    if (!certs.length) {
+    const certs = Array.isArray(data.certifications)
+      ? data.certifications
+      : [];
+    const noCerts =
+      certs.length === 0 ||
+      (certs.length === 1 && Object.keys(certs[0] || {}).length === 0);
+    if (noCerts) {
       certListEl.innerHTML = "<p>No certifications added yet.</p>";
       return;
     }

--- a/assets/js/certifications.js
+++ b/assets/js/certifications.js
@@ -148,8 +148,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const id = item.dataset.id;
     if (editBtn) {
       const name = item.querySelector("strong")?.textContent || "";
-      const status = item
-        .querySelector("em")?.textContent.replace(/[()]/g, "") || "";
+      const status =
+        item.querySelector("em")?.textContent.replace(/[()]/g, "") || "";
       const [issue, valid] =
         item.querySelector("small")?.textContent.split(" - ") || ["", ""];
       showCertForm({
@@ -163,6 +163,7 @@ document.addEventListener("DOMContentLoaded", () => {
       deleteCertification(id);
     }
   });
-
-  loadCertifications();
 });
+
+// Immediately load certifications when the script executes
+loadCertifications();

--- a/assets/js/certifications.js
+++ b/assets/js/certifications.js
@@ -149,8 +149,8 @@ function showCertForm(opts = {}) {
       let url;
       let body;
       if (isEdit) {
-        url = "https://n8n.e57.dk/webhook/pilot-dashboard/update-certification";
-        body = JSON.stringify({ token, certification_id: opts._id, updates });
+        url = "https://n8n.e57.dk/webhook/pilot-dashboard/edit-certification";
+        body = JSON.stringify({ token, cert_id: opts._id, updates });
       } else {
         url = "https://n8n.e57.dk/webhook/pilot-dashboard/add-certification";
         const payload = { token, ...updates };
@@ -182,9 +182,9 @@ async function deleteCertification(id) {
     const res = await fetch(
       "https://n8n.e57.dk/webhook/pilot-dashboard/delete-certification",
       {
-        method: "POST",
+        method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token, certification_id: id }),
+        body: JSON.stringify({ token, cert_id: id }),
       }
     );
     const text = await res.text();
@@ -216,8 +216,8 @@ document.addEventListener("DOMContentLoaded", () => {
       validUntilDate: item.dataset.validUntilDate,
     });
   });
-});
 
-  // Immediately load certifications when the script executes
+  // Load certifications once the DOM is ready
   loadCertifications();
+});
 })();

--- a/user.html
+++ b/user.html
@@ -140,6 +140,7 @@
                 <button
                   id="addCertBtn"
                   class="edit-btn"
+                  type="button"
                   title="Add Certification">➕</button>
                 <button class="fullscreen-btn" title="Fullscreen">⛶</button>
               </div>

--- a/user.html
+++ b/user.html
@@ -167,8 +167,8 @@
     <script src="assets/js/nav.js" defer></script>
     <script src="assets/js/simpleMarkdown.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="assets/js/user.js" defer></script>
     <script src="assets/js/certifications.js" defer></script>
+    <script src="assets/js/user.js" defer></script>
     <script src="assets/js/darkmode.js" defer></script>
   </body>
 </html>

--- a/user.html
+++ b/user.html
@@ -134,6 +134,21 @@
               </div>
             </div>
 
+            <!-- Widget: Certifications -->
+            <div class="widget" id="certWidget">
+              <div class="widget-buttons">
+                <button
+                  id="addCertBtn"
+                  class="edit-btn"
+                  title="Add Certification">➕</button>
+                <button class="fullscreen-btn" title="Fullscreen">⛶</button>
+              </div>
+              <h3>🏅 Certifications</h3>
+              <div id="certList">
+                <p>Loading...</p>
+              </div>
+            </div>
+
           </div>
         </section>
       </main>
@@ -152,6 +167,7 @@
     <script src="assets/js/simpleMarkdown.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="assets/js/user.js" defer></script>
+    <script src="assets/js/certifications.js" defer></script>
     <script src="assets/js/darkmode.js" defer></script>
   </body>
 </html>

--- a/user.html
+++ b/user.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="assets/css/nav.css" />
     <link rel="stylesheet" href="assets/css/darkmode.css" />
     <link rel="stylesheet" href="assets/css/widgets.css" />
+    <link rel="stylesheet" href="assets/css/forms.css" />
     <script defer src="assets/js/header.js"></script>
     <script defer src="assets/js/user-menu.js"></script>
   </head>


### PR DESCRIPTION
## Summary
- add a new certifications widget on the user profile page
- implement CRUD operations via new `certifications.js`
- include styling for certification list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6845fd3911d8832f8a61b4af297e672c