### PR TITLE
Fix duration with engine time

### DIFF
--- a/add-flight.html
+++ b/add-flight.html
@@ -139,6 +139,9 @@
                   name="engineTimeMinutes"
                   placeholder="Engine Time (minutes)"
                   min="0" />
+                <div class="manual-plane-tip" style="margin-top: 10px; font-size: 14px; color: #666">
+                  Note: For gliders with engines, duration equals soaring time plus engine time.
+                </div>
               </div>
 
               <input

--- a/add-flights.html
+++ b/add-flights.html
@@ -59,7 +59,10 @@
                 <input type="number" id="totalEngineTimeMinutes" name="totalEngineTimeMinutes" placeholder="Total Engine Time (minutes)" min="0" />
               </div>
               <div id="airTimeFields" style="display: none">
-                <input type="number" id="totalAirTimeMinutes" name="totalAirTimeMinutes" placeholder="Total Air Time (minutes)" min="0" />
+                <input type="number" id="totalAirTimeMinutes" name="totalAirTimeMinutes" placeholder="Total soaring time (engine off, minutes)" min="0" />
+              </div>
+              <div class="manual-plane-tip" style="margin-top: 10px; font-size: 14px; color: #666">
+                Note: For gliders with engines, duration equals soaring time plus engine time.
               </div>
             </fieldset>
 

--- a/assets/js/user.js
+++ b/assets/js/user.js
@@ -174,13 +174,27 @@ function getFlightCount(flight) {
 }
 
 function getFlightMinutes(flight) {
-  if (flight.airTimeMinutes != null) return flight.airTimeMinutes;
   if (flight.takeoffTime && flight.landingTime) {
-    const start = new Date(flight.takeoffTime);
-    const end = new Date(flight.landingTime);
-    const diff = end - start;
-    return diff > 0 ? Math.floor(diff / 60000) : 0;
+    const diff = new Date(flight.landingTime) - new Date(flight.takeoffTime);
+    if (diff > 0) return Math.floor(diff / 60000);
   }
+
+  if (flight.airTimeMinutes != null || flight.engineTimeMinutes != null) {
+    let total = 0;
+    if (flight.airTimeMinutes != null) total += flight.airTimeMinutes;
+    if (flight.engineTimeMinutes != null) {
+      if (
+        flight.category === "Glider (SSG)" ||
+        flight.category === "Glider (SLG)"
+      ) {
+        total += flight.engineTimeMinutes;
+      } else if (flight.airTimeMinutes == null) {
+        total += flight.engineTimeMinutes;
+      }
+    }
+    return total;
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
## Summary
- compute duration with engine time included
- document glider duration calculation
- rename batch air time field to 'Total soaring time'

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_b_684632556fb8832fbb26557808f954a1