### PR TITLE
Allow data URI plane images

### DIFF
--- a/planes.html
+++ b/planes.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; connect-src 'self' https://n8n.e57.dk; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+      content="default-src 'self'; script-src 'self'; connect-src 'self' https://n8n.e57.dk; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
     />
     <title>My Planes | Pilot Dashboard</title>
     <link rel="icon" href="assets/img/favicon.ico" />


### PR DESCRIPTION
## Summary
- Permit base64-encoded images by adding `img-src 'self' data:` to planes page CSP

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689a05009870832f9bd665ab1f14bb45